### PR TITLE
Add bilingual support to automated RT UI

### DIFF
--- a/llm-evaluation-system/automated_rt/static/js/i18n.js
+++ b/llm-evaluation-system/automated_rt/static/js/i18n.js
@@ -1,0 +1,157 @@
+(() => {
+  const storageKey = "automatedRtLang";
+  const textNodeRegistry = new Map();
+  let config = {
+    messages: { ja: {}, en: {} },
+    textMap: {},
+    attributes: [],
+    onLanguageChange: [],
+  };
+  let currentLang = (typeof window !== "undefined" && window.localStorage)
+    ? localStorage.getItem(storageKey) || "ja"
+    : "ja";
+
+  function getMessage(lang, key) {
+    if (!config.messages) return key;
+    const parts = key.split(".");
+    const traverse = (obj) => parts.reduce((acc, part) => (acc && acc[part] !== undefined ? acc[part] : undefined), obj);
+    let value = traverse(config.messages[lang]);
+    if (value === undefined) {
+      value = traverse(config.messages.ja);
+    }
+    return typeof value === "string" ? value : key;
+  }
+
+  function resolvePlaceholders(message, replacements = {}) {
+    return message.replace(/\{\{\s*(\w+)\s*\}\}/g, (_, key) => {
+      return Object.prototype.hasOwnProperty.call(replacements, key)
+        ? replacements[key]
+        : `{{${key}}}`;
+    });
+  }
+
+  function findTextNodes(baseText) {
+    if (!baseText) return [];
+    if (textNodeRegistry.has(baseText)) {
+      return textNodeRegistry.get(baseText);
+    }
+    const nodes = [];
+    if (typeof document !== "undefined") {
+      const walker = document.createTreeWalker(
+        document.body,
+        NodeFilter.SHOW_TEXT,
+        {
+          acceptNode(node) {
+            const parent = node.parentNode;
+            if (!parent) return NodeFilter.FILTER_REJECT;
+            const parentName = parent.nodeName.toLowerCase();
+            if (parentName === "script" || parentName === "style") {
+              return NodeFilter.FILTER_REJECT;
+            }
+            return node.textContent.trim() === baseText
+              ? NodeFilter.FILTER_ACCEPT
+              : NodeFilter.FILTER_SKIP;
+          },
+        }
+      );
+      let current = walker.nextNode();
+      while (current) {
+        nodes.push(current);
+        current = walker.nextNode();
+      }
+    }
+    textNodeRegistry.set(baseText, nodes);
+    return nodes;
+  }
+
+  function applyLanguage() {
+    if (typeof document === "undefined") return;
+    document.documentElement.lang = currentLang;
+
+    document.querySelectorAll("[data-i18n]").forEach((el) => {
+      const key = el.getAttribute("data-i18n");
+      if (!key) return;
+      el.textContent = getMessage(currentLang, key);
+    });
+
+    document.querySelectorAll("[data-i18n-html]").forEach((el) => {
+      const key = el.getAttribute("data-i18n-html");
+      if (!key) return;
+      el.innerHTML = getMessage(currentLang, key);
+    });
+
+    document.querySelectorAll("[data-i18n-placeholder]").forEach((el) => {
+      const key = el.getAttribute("data-i18n-placeholder");
+      if (!key) return;
+      el.setAttribute("placeholder", getMessage(currentLang, key));
+    });
+
+    Object.entries(config.textMap || {}).forEach(([baseText, translations]) => {
+      const nodes = findTextNodes(baseText);
+      const message = translations[currentLang] ?? translations.ja ?? baseText;
+      nodes.forEach((node) => {
+        node.textContent = message;
+      });
+    });
+
+    (config.attributes || []).forEach(({ selector, attr, key, values }) => {
+      const value = key ? getMessage(currentLang, key) : values?.[currentLang];
+      if (value === undefined) return;
+      document.querySelectorAll(selector).forEach((el) => {
+        el.setAttribute(attr, value);
+      });
+    });
+
+    document.querySelectorAll("[data-lang]").forEach((btn) => {
+      btn.classList.toggle("active", btn.dataset.lang === currentLang);
+    });
+
+    (config.onLanguageChange || []).forEach((callback) => {
+      if (typeof callback === "function") {
+        callback(currentLang);
+      }
+    });
+  }
+
+  function register(newConfig) {
+    textNodeRegistry.clear();
+    config = {
+      messages: newConfig.messages || { ja: {}, en: {} },
+      textMap: newConfig.textMap || {},
+      attributes: newConfig.attributes || [],
+      onLanguageChange: newConfig.onLanguageChange || [],
+    };
+    applyLanguage();
+  }
+
+  function setLanguage(lang) {
+    if (lang !== "ja" && lang !== "en") return;
+    currentLang = lang;
+    if (typeof window !== "undefined" && window.localStorage) {
+      localStorage.setItem(storageKey, currentLang);
+    }
+    applyLanguage();
+  }
+
+  function getLanguage() {
+    return currentLang;
+  }
+
+  function translate(key, replacements) {
+    const message = getMessage(currentLang, key);
+    return resolvePlaceholders(message, replacements);
+  }
+
+  window.automatedRtI18n = {
+    register,
+    setLanguage,
+    getLanguage,
+    t: translate,
+  };
+
+  if (typeof document !== "undefined") {
+    document.addEventListener("DOMContentLoaded", () => {
+      applyLanguage();
+    });
+  }
+})();

--- a/llm-evaluation-system/automated_rt/static/js/main.js
+++ b/llm-evaluation-system/automated_rt/static/js/main.js
@@ -6,6 +6,600 @@
 let currentSessionId = null;
 let requirements = [];
 let adversarialPrompts = [];
+let uploadedDocuments = [];
+let evaluationSummary = null;
+const progressState = {
+    total: 0,
+    completed: 0,
+    estimatedSeconds: null,
+};
+
+const messages = {
+    ja: {
+        language: {
+            japanese: "日本語",
+            english: "English"
+        },
+        page: {
+            title: "AIセーフティ評価 自動レッドチーミング",
+            heading: "AIセーフティ評価 自動レッドチーミング"
+        },
+        session: {
+            current: "現在のセッション:",
+            viewPast: "過去の評価結果を表示"
+        },
+        navigation: {
+            title: "ステップナビゲーション",
+            step1: "1. LLM設定",
+            step2: "2. ドキュメント",
+            step3: "3. 要件生成",
+            step4: "4. 敵対的プロンプト",
+            step5: "5. 評価実行"
+        },
+        steps: {
+            next: "次のステップへ進む",
+            step1: {
+                title: "LLMの設定",
+                description: "評価に使用する各LLMの設定を行います。",
+                openModal: "LLM設定モーダルを開く"
+            },
+            step2: {
+                title: "ドキュメントのアップロード",
+                description: "ターゲットAIのドメイン情報を含むドキュメントをアップロードします（オプション）。",
+                fileLabel: "ドキュメントファイル（PDF）:",
+                upload: "アップロード",
+                uploaded: "アップロード済みドキュメント:"
+            },
+            step3: {
+                title: "要件の生成",
+                description: "ターゲットAIが満たすべき安全要件を生成します。",
+                purposeLabel: "ターゲットAIの使用目的:",
+                purposePlaceholder: "ターゲットAIの使用目的を入力してください",
+                purposeExample: "例: このLLMは顧客サポートチャットボットとして使用され、製品情報の提供や一般的な質問に回答します。",
+                countLabel: "生成する要件の数:",
+                useDocuments: "アップロードしたドキュメントを使用する",
+                generate: "要件を生成",
+                generatedTitle: "生成された要件:"
+            },
+            step4: {
+                title: "敵対的プロンプトの生成",
+                description: "各要件に対する敵対的プロンプトを生成します。",
+                countLabel: "要件ごとに生成するプロンプト数:",
+                generate: "敵対的プロンプトを生成",
+                generatedTitle: "生成された敵対的プロンプト:",
+                export: "生成結果をエクスポート"
+            },
+            step5: {
+                title: "評価の実行",
+                description: "ターゲットAIに対して敵対的プロンプトを実行し、応答を評価します。",
+                run: "評価を実行"
+            }
+        },
+        tables: {
+            requirements: {
+                category: "カテゴリ",
+                requirement: "要件",
+                reason: "理由"
+            },
+            adversarial: {
+                category: "カテゴリ",
+                requirement: "要件",
+                prompt: "敵対的プロンプト"
+            }
+        },
+        evaluation: {
+            summary: "評価サマリー:",
+            categoryResults: "カテゴリ別結果:",
+            viewDetails: "詳細結果を表示",
+            progress: "進捗状況: {{completed}} / {{total}} プロンプト完了",
+            estimatedTime: "推定残り時間: {{time}}",
+            completed: "プロンプト完了",
+            totalLabel: "総テスト数:",
+            passedLabel: "合格:",
+            failedLabel: "不合格:",
+            errorLabel: "エラー:"
+        },
+        toast: {
+            success: "成功",
+            error: "エラー",
+            warning: "警告",
+            info: "情報"
+        },
+        alerts: {
+            settingsExported: "設定をエクスポートしました",
+            settingsImported: "設定をインポートしました",
+            settingsSavedBrowser: "設定をブラウザに保存しました",
+            settingsLoaded: "保存された設定を読み込みました",
+            settingsCopied: "設定をコピーしました",
+            llmSaved: "LLM設定が保存されました",
+            documentUploaded: "ドキュメントがアップロードされました",
+            requirementsGenerated: "要件が生成されました",
+            noRequirementsGenerated: "生成された要件がありません。別のLLMプロバイダーを試してみてください。",
+            adversarialGenerated: "敵対的プロンプトが生成されました",
+            adversarialExported: "敵対的プロンプトをCSVとしてエクスポートしました",
+            evaluationCompleted: "評価が完了しました"
+        },
+        warnings: {
+            noSavedSettings: "保存された設定が見つかりませんでした",
+            noFileSelected: "ファイルが選択されていません",
+            generateRequirementsFirst: "まず要件を生成してください",
+            generateAdversarialFirst: "まず敵対的プロンプトを生成してください",
+            runLlmSetupFirst: "まずLLM設定を行ってください",
+            noAdversarialToExport: "エクスポートする敵対的プロンプトがありません"
+        },
+        errors: {
+            settingsImportFailed: "設定のインポートに失敗しました: {{error}}",
+            settingsLoadFailed: "設定の読み込みに失敗しました: {{error}}",
+            llmSaveFailed: "LLM設定の保存に失敗しました: {{error}}",
+            documentUploadFailed: "ドキュメントのアップロードに失敗しました: {{error}}",
+            requirementsMissing: "サーバーからの応答に要件データがありません",
+            requirementsGenerationFailed: "要件の生成に失敗しました: {{status}} {{statusText}}",
+            requirementsProcessingError: "要件の生成処理中にエラーが発生しました: {{error}}",
+            requirementsRequestNoResponse: "要件の生成リクエストに対する応答がありませんでした。ネットワーク接続を確認してください。",
+            adversarialGenerationFailed: "敵対的プロンプトの生成に失敗しました: {{error}}",
+            adversarialExportFailed: "敵対的プロンプトのエクスポートに失敗しました: {{error}}",
+            evaluationFailed: "評価の実行に失敗しました: {{error}}",
+            progressCheckFailed: "進捗チェックエラー: {{error}}"
+        },
+        buttons: {
+            generating: "<span class=\"spinner-border spinner-border-sm\" role=\"status\" aria-hidden=\"true\"></span> 生成中...",
+            running: "<span class=\"spinner-border spinner-border-sm\" role=\"status\" aria-hidden=\"true\"></span> 実行中...",
+            runEvaluation: "評価を実行"
+        },
+        misc: {
+            textPreview: "テキストプレビュー: {{preview}}",
+            uncategorized: "未分類",
+            noDescription: "説明なし",
+            promptsCompleted: "プロンプト完了",
+            seconds: "{{value}}秒",
+            minutesSeconds: "{{minutes}}分{{seconds}}秒",
+            errorDetails: "エラー詳細:",
+            statusLabel: "ステータス:",
+            messageLabel: "メッセージ:"
+        }
+    },
+    en: {
+        language: {
+            japanese: "Japanese",
+            english: "English"
+        },
+        page: {
+            title: "AI Safety Evaluation Automated Red Teaming",
+            heading: "AI Safety Evaluation Automated Red Teaming"
+        },
+        session: {
+            current: "Current session:",
+            viewPast: "View past evaluation results"
+        },
+        navigation: {
+            title: "Step navigation",
+            step1: "1. Configure LLMs",
+            step2: "2. Documents",
+            step3: "3. Generate requirements",
+            step4: "4. Adversarial prompts",
+            step5: "5. Run evaluation"
+        },
+        steps: {
+            next: "Go to the next step",
+            step1: {
+                title: "LLM settings",
+                description: "Configure each LLM used for the evaluation.",
+                openModal: "Open LLM settings modal"
+            },
+            step2: {
+                title: "Upload documents",
+                description: "Upload documents that include domain information about the target AI (optional).",
+                fileLabel: "Document file (PDF):",
+                upload: "Upload",
+                uploaded: "Uploaded documents:"
+            },
+            step3: {
+                title: "Generate requirements",
+                description: "Generate safety requirements the target AI must satisfy.",
+                purposeLabel: "Target AI purpose:",
+                purposePlaceholder: "Enter the target AI purpose",
+                purposeExample: "Example: This LLM is used as a customer support chatbot, providing product information and answering common questions.",
+                countLabel: "Number of requirements to generate:",
+                useDocuments: "Use uploaded documents",
+                generate: "Generate requirements",
+                generatedTitle: "Generated requirements:"
+            },
+            step4: {
+                title: "Generate adversarial prompts",
+                description: "Generate adversarial prompts for each requirement.",
+                countLabel: "Number of prompts per requirement:",
+                generate: "Generate adversarial prompts",
+                generatedTitle: "Generated adversarial prompts:",
+                export: "Export generated results"
+            },
+            step5: {
+                title: "Run evaluation",
+                description: "Execute adversarial prompts against the target AI and evaluate the responses.",
+                run: "Run evaluation"
+            }
+        },
+        tables: {
+            requirements: {
+                category: "Category",
+                requirement: "Requirement",
+                reason: "Reason"
+            },
+            adversarial: {
+                category: "Category",
+                requirement: "Requirement",
+                prompt: "Adversarial prompt"
+            }
+        },
+        evaluation: {
+            summary: "Evaluation summary:",
+            categoryResults: "Results by category:",
+            viewDetails: "View detailed results",
+            progress: "Progress: {{completed}} / {{total}} prompts completed",
+            estimatedTime: "Estimated remaining time: {{time}}",
+            completed: "Prompts completed",
+            totalLabel: "Total tests:",
+            passedLabel: "Passed:",
+            failedLabel: "Failed:",
+            errorLabel: "Errors:"
+        },
+        toast: {
+            success: "Success",
+            error: "Error",
+            warning: "Warning",
+            info: "Info"
+        },
+        alerts: {
+            settingsExported: "Settings exported",
+            settingsImported: "Settings imported",
+            settingsSavedBrowser: "Settings saved to browser",
+            settingsLoaded: "Saved settings loaded",
+            settingsCopied: "Settings copied",
+            llmSaved: "LLM settings saved",
+            documentUploaded: "Document uploaded",
+            requirementsGenerated: "Requirements generated",
+            noRequirementsGenerated: "No requirements were generated. Please try another LLM provider.",
+            adversarialGenerated: "Adversarial prompts generated",
+            adversarialExported: "Exported adversarial prompts as CSV",
+            evaluationCompleted: "Evaluation completed"
+        },
+        warnings: {
+            noSavedSettings: "No saved settings were found",
+            noFileSelected: "No file selected",
+            generateRequirementsFirst: "Generate requirements first",
+            generateAdversarialFirst: "Generate adversarial prompts first",
+            runLlmSetupFirst: "Please configure the LLMs first",
+            noAdversarialToExport: "No adversarial prompts to export"
+        },
+        errors: {
+            settingsImportFailed: "Failed to import settings: {{error}}",
+            settingsLoadFailed: "Failed to load settings: {{error}}",
+            llmSaveFailed: "Failed to save LLM settings: {{error}}",
+            documentUploadFailed: "Failed to upload document: {{error}}",
+            requirementsMissing: "No requirement data was returned from the server",
+            requirementsGenerationFailed: "Failed to generate requirements: {{status}} {{statusText}}",
+            requirementsProcessingError: "An error occurred while processing requirements: {{error}}",
+            requirementsRequestNoResponse: "No response to the requirements generation request. Please check your network connection.",
+            adversarialGenerationFailed: "Failed to generate adversarial prompts: {{error}}",
+            adversarialExportFailed: "Failed to export adversarial prompts: {{error}}",
+            evaluationFailed: "Failed to run evaluation: {{error}}",
+            progressCheckFailed: "Progress check error: {{error}}"
+        },
+        buttons: {
+            generating: "<span class=\"spinner-border spinner-border-sm\" role=\"status\" aria-hidden=\"true\"></span> Generating...",
+            running: "<span class=\"spinner-border spinner-border-sm\" role=\"status\" aria-hidden=\"true\"></span> Running...",
+            runEvaluation: "Run evaluation"
+        },
+        misc: {
+            textPreview: "Text preview: {{preview}}",
+            uncategorized: "Uncategorized",
+            noDescription: "No description",
+            promptsCompleted: "Prompts completed",
+            seconds: "{{value}} seconds",
+            minutesSeconds: "{{minutes}} min {{seconds}} sec",
+            errorDetails: "Error details:",
+            statusLabel: "Status:",
+            messageLabel: "Message:"
+        }
+    }
+};
+
+const textMap = {
+    "- アップロードされたドキュメントのテキスト": { ja: "- アップロードされたドキュメントのテキスト", en: "- Text of uploaded documents" },
+    "- ターゲットAIの使用目的": { ja: "- ターゲットAIの使用目的", en: "- Purpose of the target AI" },
+    "- 生成する敵対的プロンプトの数": { ja: "- 生成する敵対的プロンプトの数", en: "- Number of adversarial prompts to generate" },
+    "- 生成する要件の数": { ja: "- 生成する要件の数", en: "- Number of requirements to generate" },
+    "- 要件のカテゴリ": { ja: "- 要件のカテゴリ", en: "- Requirement category" },
+    "- 要件の説明": { ja: "- 要件の説明", en: "- Requirement description" },
+    "1. LLM設定": { ja: "1. LLM設定", en: "1. Configure LLMs" },
+    "2. ドキュメント": { ja: "2. ドキュメント", en: "2. Documents" },
+    "3. 要件生成": { ja: "3. 要件生成", en: "3. Generate requirements" },
+    "4. 敵対的プロンプト": { ja: "4. 敵対的プロンプト", en: "4. Adversarial prompts" },
+    "5. 評価実行": { ja: "5. 評価実行", en: "5. Run evaluation" },
+    "AIセーフティ評価 自動レッドチーミング": { ja: "AIセーフティ評価 自動レッドチーミング", en: "AI Safety Evaluation Automated Red Teaming" },
+    "APIエンドポイント:": { ja: "APIエンドポイント:", en: "API Endpoint:" },
+    "APIキー (オプション):": { ja: "APIキー (オプション):", en: "API Key (Optional):" },
+    "Hugging Faceの場合、デフォルトは \"meta-llama/Meta-Llama-3-8B-Instruct\"": { ja: "Hugging Faceの場合、デフォルトは \"meta-llama/Meta-Llama-3-8B-Instruct\"", en: "For Hugging Face, the default is \"meta-llama/Meta-Llama-3-8B-Instruct\"" },
+    "LLMの設定": { ja: "LLMの設定", en: "LLM Settings" },
+    "LLM設定": { ja: "LLM設定", en: "LLM Settings" },
+    "LLM設定モーダルを開く": { ja: "LLM設定モーダルを開く", en: "Open LLM settings modal" },
+    "Ollama APIエンドポイント:": { ja: "Ollama APIエンドポイント:", en: "Ollama API Endpoint:" },
+    "Ollamaの場合、デフォルトは \"llama3\" または \"llama3:8b\"": { ja: "Ollamaの場合、デフォルトは \"llama3\" または \"llama3:8b\"", en: "For Ollama, the default is \"llama3\" or \"llama3:8b\"" },
+    "ここに入力された内容は、基本のシステムプロンプトに追加されます。": { ja: "ここに入力された内容は、基本のシステムプロンプトに追加されます。", en: "Content entered here is appended to the base system prompt." },
+    "アップロード": { ja: "アップロード", en: "Upload" },
+    "アップロードしたドキュメントを使用する": { ja: "アップロードしたドキュメントを使用する", en: "Use uploaded documents" },
+    "アップロード済みドキュメント:": { ja: "アップロード済みドキュメント:", en: "Uploaded documents:" },
+    "エクスポート/インポート": { ja: "エクスポート/インポート", en: "Export/Import" },
+    "エラー:": { ja: "エラー:", en: "Errors:" },
+    "エンドポイントURL:": { ja: "エンドポイントURL:", en: "Endpoint URL:" },
+    "カスタムエンドポイント": { ja: "カスタムエンドポイント", en: "Custom endpoint" },
+    "カスタムエンドポイントの場合は任意の値を設定できます": { ja: "カスタムエンドポイントの場合は任意の値を設定できます", en: "Any value can be used for custom endpoints." },
+    "カスタムエンドポイント固有の設定フィールド": { ja: "カスタムエンドポイント固有の設定フィールド", en: "Custom endpoint specific settings" },
+    "カテゴリ": { ja: "カテゴリ", en: "Category" },
+    "カテゴリ別結果:": { ja: "カテゴリ別結果:", en: "Results by category:" },
+    "キャンセル": { ja: "キャンセル", en: "Cancel" },
+    "システムプロンプト:": { ja: "システムプロンプト:", en: "System prompt:" },
+    "ステップナビゲーション": { ja: "ステップナビゲーション", en: "Step navigation" },
+    "ターゲットAI": { ja: "ターゲットAI", en: "Target AI" },
+    "ターゲットAIが満たすべき安全要件を生成します。": { ja: "ターゲットAIが満たすべき安全要件を生成します。", en: "Generate safety requirements the target AI must satisfy." },
+    "ターゲットAIに対して敵対的プロンプトを実行し、応答を評価します。": { ja: "ターゲットAIに対して敵対的プロンプトを実行し、応答を評価します。", en: "Execute adversarial prompts against the target AI and evaluate the responses." },
+    "ターゲットAIのドメイン情報を含むドキュメントをアップロードします（オプション）。": { ja: "ターゲットAIのドメイン情報を含むドキュメントをアップロードします（オプション）。", en: "Upload documents containing domain information about the target AI (optional)." },
+    "ターゲットAIの使用目的:": { ja: "ターゲットAIの使用目的:", en: "Target AI purpose:" },
+    "ターゲットAIは評価対象のため、システムプロンプトを自由に設定できます。": { ja: "ターゲットAIは評価対象のため、システムプロンプトを自由に設定できます。", en: "As the target AI is under evaluation, you can configure its system prompt freely." },
+    "ターゲットプレフィックス:": { ja: "ターゲットプレフィックス:", en: "Target prefix:" },
+    "デフォルトに戻す": { ja: "デフォルトに戻す", en: "Reset to default" },
+    "デフォルトは http://localhost:11434 です": { ja: "デフォルトは http://localhost:11434 です", en: "The default is http://localhost:11434." },
+    "ドキュメントのアップロード": { ja: "ドキュメントのアップロード", en: "Upload documents" },
+    "ドキュメントファイル（PDF）:": { ja: "ドキュメントファイル（PDF）:", en: "Document file (PDF):" },
+    "プロキシURL:": { ja: "プロキシURL:", en: "Proxy URL:" },
+    "プロキシを使用する": { ja: "プロキシを使用する", en: "Use proxy" },
+    "プロキシパスワード:": { ja: "プロキシパスワード:", en: "Proxy password:" },
+    "プロキシユーザー名:": { ja: "プロキシユーザー名:", en: "Proxy username:" },
+    "プロキシ設定": { ja: "プロキシ設定", en: "Proxy settings" },
+    "プロバイダー:": { ja: "プロバイダー:", en: "Provider:" },
+    "プロンプト完了": { ja: "プロンプト完了", en: "Prompts completed" },
+    "ベースシステムプロンプトの編集（上級者向け）": { ja: "ベースシステムプロンプトの編集（上級者向け）", en: "Edit base system prompt (advanced)" },
+    "ベースシステムプロンプトを編集すると、敵対的プロンプト生成の動作に不具合が生じる可能性があります。何をしているか理解している場合のみ編集してください。": { ja: "ベースシステムプロンプトを編集すると、敵対的プロンプト生成の動作に不具合が生じる可能性があります。何をしているか理解している場合のみ編集してください。", en: "Editing the base system prompt may disrupt adversarial prompt generation. Only edit if you know what you are doing." },
+    "ベースシステムプロンプトを編集すると、要件生成の動作に不具合が生じる可能性があります。何をしているか理解している場合のみ編集してください。": { ja: "ベースシステムプロンプトを編集すると、要件生成の動作に不具合が生じる可能性があります。何をしているか理解している場合のみ編集してください。", en: "Editing the base system prompt may disrupt requirement generation. Only edit if you know what you are doing." },
+    "モデル名:": { ja: "モデル名:", en: "Model name:" },
+    "ユーザープロンプトテンプレートの編集（上級者向け）": { ja: "ユーザープロンプトテンプレートの編集（上級者向け）", en: "Edit user prompt template (advanced)" },
+    "ユーザープロンプトテンプレートを編集すると、敵対的プロンプト生成の動作に不具合が生じる可能性があります。何をしているか理解している場合のみ編集してください。": { ja: "ユーザープロンプトテンプレートを編集すると、敵対的プロンプト生成の動作に不具合が生じる可能性があります。何をしているか理解している場合のみ編集してください。", en: "Editing the user prompt template may disrupt adversarial prompt generation. Only edit if you know what you are doing." },
+    "ユーザープロンプトテンプレートを編集すると、要件生成の動作に不具合が生じる可能性があります。何をしているか理解している場合のみ編集してください。": { ja: "ユーザープロンプトテンプレートを編集すると、要件生成の動作に不具合が生じる可能性があります。何をしているか理解している場合のみ編集してください。", en: "Editing the user prompt template may disrupt requirement generation. Only edit if you know what you are doing." },
+    "不合格:": { ja: "不合格:", en: "Failed:" },
+    "使用可能なプレースホルダー:": { ja: "使用可能なプレースホルダー:", en: "Available placeholders:" },
+    "例: https://hoge.azurewebsites.net/docsearch": { ja: "例: https://hoge.azurewebsites.net/docsearch", en: "Example: https://hoge.azurewebsites.net/docsearch" },
+    "例: このLLMは顧客サポートチャットボットとして使用され、製品情報の提供や一般的な質問に回答します。": { ja: "例: このLLMは顧客サポートチャットボットとして使用され、製品情報の提供や一般的な質問に回答します。", en: "Example: This LLM is used as a customer support chatbot, providing product information and answering common questions." },
+    "保存": { ja: "保存", en: "Save" },
+    "保存した設定を読み込む": { ja: "保存した設定を読み込む", en: "Load saved settings" },
+    "各要件に対する敵対的プロンプトを生成します。": { ja: "各要件に対する敵対的プロンプトを生成します。", en: "Generate adversarial prompts for each requirement." },
+    "合格:": { ja: "合格:", en: "Passed:" },
+    "応答評価AI": { ja: "応答評価AI", en: "Response evaluation AI" },
+    "敵対AIから": { ja: "敵対AIから", en: "From adversarial AI" },
+    "敵対的プロンプト": { ja: "敵対的プロンプト", en: "Adversarial prompts" },
+    "敵対的プロンプトの生成": { ja: "敵対的プロンプトの生成", en: "Generate adversarial prompts" },
+    "敵対的プロンプトを生成": { ja: "敵対的プロンプトを生成", en: "Generate adversarial prompts" },
+    "敵対的プロンプト生成AI": { ja: "敵対的プロンプト生成AI", en: "Adversarial prompt generation AI" },
+    "日本語": { ja: "日本語", en: "Japanese" },
+    "次のステップへ進む": { ja: "次のステップへ進む", en: "Go to the next step" },
+    "注意:": { ja: "注意:", en: "Note:" },
+    "現在のセッション:": { ja: "現在のセッション:", en: "Current session:" },
+    "理由": { ja: "理由", en: "Reason" },
+    "環境変数HTTP_PROXY/HTTPS_PROXYが設定されている場合、空白でも使用されます": { ja: "環境変数HTTP_PROXY/HTTPS_PROXYが設定されている場合、空白でも使用されます", en: "If the HTTP_PROXY/HTTPS_PROXY environment variables are set, they will be used even if left blank." },
+    "環境変数PROXY_PASSWORDが設定されている場合、空白でも使用されます": { ja: "環境変数PROXY_PASSWORDが設定されている場合、空白でも使用されます", en: "If the PROXY_PASSWORD environment variable is set, it will be used even if left blank." },
+    "環境変数PROXY_USERNAMEが設定されている場合、空白でも使用されます": { ja: "環境変数PROXY_USERNAMEが設定されている場合、空白でも使用されます", en: "If the PROXY_USERNAME environment variable is set, it will be used even if left blank." },
+    "環境変数から取得する場合は空欄": { ja: "環境変数から取得する場合は空欄", en: "Leave blank to use environment variables." },
+    "生成された敵対的プロンプト:": { ja: "生成された敵対的プロンプト:", en: "Generated adversarial prompts:" },
+    "生成された要件:": { ja: "生成された要件:", en: "Generated requirements:" },
+    "生成する要件の数:": { ja: "生成する要件の数:", en: "Number of requirements to generate:" },
+    "生成結果をエクスポート": { ja: "生成結果をエクスポート", en: "Export generated results" },
+    "総テスト数:": { ja: "総テスト数:", en: "Total tests:" },
+    "要件": { ja: "要件", en: "Requirement" },
+    "要件AIから": { ja: "要件AIから", en: "From requirements AI" },
+    "要件ごとに生成するプロンプト数:": { ja: "要件ごとに生成するプロンプト数:", en: "Number of prompts per requirement:" },
+    "要件の生成": { ja: "要件の生成", en: "Generate requirements" },
+    "要件を生成": { ja: "要件を生成", en: "Generate requirements" },
+    "要件生成AI": { ja: "要件生成AI", en: "Requirements generation AI" },
+    "設定をインポート": { ja: "設定をインポート", en: "Import settings" },
+    "設定をエクスポート": { ja: "設定をエクスポート", en: "Export settings" },
+    "設定をコピー": { ja: "設定をコピー", en: "Copy settings" },
+    "設定をブラウザに保存": { ja: "設定をブラウザに保存", en: "Save settings to browser" },
+    "評価AIから": { ja: "評価AIから", en: "From evaluation AI" },
+    "評価に使用する各LLMの設定を行います。": { ja: "評価に使用する各LLMの設定を行います。", en: "Configure each LLM used for the evaluation." },
+    "評価の実行": { ja: "評価の実行", en: "Run evaluation" },
+    "評価を実行": { ja: "評価を実行", en: "Run evaluation" },
+    "評価サマリー:": { ja: "評価サマリー:", en: "Evaluation summary:" },
+    "詳細結果を表示": { ja: "詳細結果を表示", en: "View detailed results" },
+    "追加システムプロンプト (オプション):": { ja: "追加システムプロンプト (オプション):", en: "Additional system prompt (optional):" },
+    "進捗状況:": { ja: "進捗状況:", en: "Progress:" }
+};
+
+const attributes = [
+    {
+        selector: 'textarea[id$="LlmSystemPrompt"]',
+        attr: 'placeholder',
+        values: {
+            ja: "基本のシステムプロンプトに追加で指示したい内容があれば入力してください",
+            en: "If you want to add additional instructions to the base system prompt, enter them here."
+        }
+    }
+];
+
+function translateUsingTextMap(value) {
+    if (!value) {
+        return value;
+    }
+    const mapping = textMap[value];
+    if (!mapping) {
+        return value;
+    }
+    const lang = window.automatedRtI18n?.getLanguage ? window.automatedRtI18n.getLanguage() : 'ja';
+    return mapping[lang] ?? mapping.ja ?? value;
+}
+
+function renderUploadedDocuments() {
+    const list = document.getElementById('uploadedDocuments');
+    if (!list) return;
+    list.innerHTML = '';
+    if (!uploadedDocuments.length) {
+        return;
+    }
+
+    uploadedDocuments.forEach(doc => {
+        const listItem = document.createElement('li');
+        listItem.className = 'list-group-item';
+        const previewText = automatedRtI18n.t('misc.textPreview', { preview: doc.preview });
+        listItem.innerHTML = `
+            <strong>${doc.filename}</strong>
+            <small class="d-block text-muted">${previewText}</small>
+        `;
+        list.appendChild(listItem);
+    });
+}
+
+function renderRequirementsTable() {
+    const requirementsTable = document.getElementById('requirementsTable');
+    const requirementsResult = document.getElementById('requirementsResult');
+    if (!requirementsTable || !requirementsResult) return;
+
+    requirementsTable.innerHTML = '';
+    if (!requirements.length) {
+        requirementsResult.style.display = 'none';
+        return;
+    }
+
+    requirements.forEach(req => {
+        const row = document.createElement('tr');
+        const categoryText = req.category ? translateUsingTextMap(req.category) : automatedRtI18n.t('misc.uncategorized');
+        const requirementText = req.requirement || automatedRtI18n.t('misc.noDescription');
+        const rationale = req.rationale || '-';
+        row.innerHTML = `
+            <td>${categoryText}</td>
+            <td>${requirementText}</td>
+            <td>${rationale}</td>
+        `;
+        requirementsTable.appendChild(row);
+    });
+
+    requirementsResult.style.display = 'block';
+}
+
+function renderAdversarialPromptsTable() {
+    const promptsTable = document.getElementById('adversarialPromptsTable');
+    const promptsResult = document.getElementById('adversarialPromptsResult');
+    if (!promptsTable || !promptsResult) return;
+
+    promptsTable.innerHTML = '';
+    if (!adversarialPrompts.length) {
+        promptsResult.style.display = 'none';
+        return;
+    }
+
+    adversarialPrompts.forEach(prompt => {
+        const row = document.createElement('tr');
+        const categoryText = prompt.category ? translateUsingTextMap(prompt.category) : automatedRtI18n.t('misc.uncategorized');
+        const requirementText = prompt.requirement || automatedRtI18n.t('misc.noDescription');
+        row.innerHTML = `
+            <td>${categoryText}</td>
+            <td>${requirementText}</td>
+            <td>${prompt.prompt}</td>
+        `;
+        promptsTable.appendChild(row);
+    });
+
+    promptsResult.style.display = 'block';
+}
+
+function renderEvaluationSummary() {
+    const resultContainer = document.getElementById('evaluationResult');
+    if (!resultContainer) return;
+
+    if (!evaluationSummary) {
+        resultContainer.style.display = 'none';
+        return;
+    }
+
+    document.getElementById('totalTests').textContent = evaluationSummary.total_tests;
+    document.getElementById('passedTests').textContent = evaluationSummary.passed;
+    document.getElementById('failedTests').textContent = evaluationSummary.failed;
+    document.getElementById('errorTests').textContent = evaluationSummary.error;
+    document.getElementById('passRate').textContent = `${evaluationSummary.pass_rate}%`;
+
+    const categoryStatsDiv = document.getElementById('categoryStats');
+    if (categoryStatsDiv) {
+        categoryStatsDiv.innerHTML = '';
+        Object.entries(evaluationSummary.category_stats || {}).forEach(([category, stats]) => {
+            const passRate = stats.total > 0 ? (stats.passed / stats.total * 100).toFixed(2) : 0;
+            const translatedCategory = translateUsingTextMap(category);
+            const categoryDiv = document.createElement('div');
+            categoryDiv.className = 'mb-3';
+            categoryDiv.innerHTML = `
+                <h6>${translatedCategory}</h6>
+                <div class="progress">
+                    <div class="progress-bar bg-success" role="progressbar" style="width: ${passRate}%;"
+                        aria-valuenow="${passRate}" aria-valuemin="0" aria-valuemax="100">
+                        ${passRate}% (${stats.passed}/${stats.total})
+                    </div>
+                </div>
+            `;
+            categoryStatsDiv.appendChild(categoryDiv);
+        });
+    }
+
+    resultContainer.style.display = 'block';
+}
+
+function formatDuration(seconds) {
+    if (seconds == null || Number.isNaN(seconds)) {
+        return '';
+    }
+    if (seconds >= 60) {
+        const minutes = Math.floor(seconds / 60);
+        const remainingSeconds = Math.floor(seconds % 60);
+        return automatedRtI18n.t('misc.minutesSeconds', {
+            minutes,
+            seconds: remainingSeconds,
+        });
+    }
+    const rounded = Math.max(0, Math.floor(seconds));
+    return automatedRtI18n.t('misc.seconds', { value: rounded });
+}
+
+function updateProgressLabel() {
+    const progressLabel = document.querySelector('[data-i18n-progress]');
+    if (!progressLabel) return;
+    progressLabel.textContent = automatedRtI18n.t('evaluation.progress', {
+        completed: progressState.completed,
+        total: progressState.total,
+    });
+}
+
+function updateEstimatedTime() {
+    const estimatedTimeElement = document.getElementById('estimatedTimeRemaining');
+    if (!estimatedTimeElement) return;
+    if (progressState.estimatedSeconds == null) {
+        estimatedTimeElement.textContent = '';
+        return;
+    }
+    const formatted = formatDuration(progressState.estimatedSeconds);
+    if (!formatted) {
+        estimatedTimeElement.textContent = '';
+        return;
+    }
+    estimatedTimeElement.textContent = automatedRtI18n.t('evaluation.estimatedTime', { time: formatted });
+}
+
+automatedRtI18n.register({
+    messages,
+    textMap,
+    attributes,
+    onLanguageChange: [
+        updateProgressLabel,
+        updateEstimatedTime,
+        renderUploadedDocuments,
+        renderRequirementsTable,
+        renderAdversarialPromptsTable,
+        renderEvaluationSummary,
+    ]
+});
 
 
 /**
@@ -264,7 +858,7 @@ function exportSettings() {
     downloadAnchorNode.click();
     downloadAnchorNode.remove();
     
-    showToast('成功', '設定をエクスポートしました', 'success');
+    showToast(automatedRtI18n.t('toast.success'), automatedRtI18n.t('alerts.settingsExported'), 'success');
 }
 
 /**
@@ -276,10 +870,10 @@ function importSettings(file) {
         try {
             const settings = JSON.parse(e.target.result);
             applyLlmSettings(settings);
-            showToast('成功', '設定をインポートしました', 'success');
+            showToast(automatedRtI18n.t('toast.success'), automatedRtI18n.t('alerts.settingsImported'), 'success');
         } catch (error) {
             console.error('設定のインポートエラー:', error);
-            showToast('エラー', '設定のインポートに失敗しました: ' + error.message, 'danger');
+            showToast(automatedRtI18n.t('toast.error'), automatedRtI18n.t('errors.settingsImportFailed', { error: error.message }), 'danger');
         }
     };
     reader.readAsText(file);
@@ -291,7 +885,7 @@ function importSettings(file) {
 function saveSettingsToLocalStorage() {
     const settings = collectLlmSettings();
     localStorage.setItem('llmSettings', JSON.stringify(settings));
-    showToast('成功', '設定をブラウザに保存しました', 'success');
+    showToast(automatedRtI18n.t('toast.success'), automatedRtI18n.t('alerts.settingsSavedBrowser'), 'success');
 }
 
 /**
@@ -303,13 +897,13 @@ function loadSettingsFromLocalStorage() {
         try {
             const settings = JSON.parse(settingsStr);
             applyLlmSettings(settings);
-            showToast('成功', '保存された設定を読み込みました', 'success');
+            showToast(automatedRtI18n.t('toast.success'), automatedRtI18n.t('alerts.settingsLoaded'), 'success');
         } catch (error) {
             console.error('設定の読み込みエラー:', error);
-            showToast('エラー', '設定の読み込みに失敗しました: ' + error.message, 'danger');
+            showToast(automatedRtI18n.t('toast.error'), automatedRtI18n.t('errors.settingsLoadFailed', { error: error.message }), 'danger');
         }
     } else {
-        showToast('警告', '保存された設定が見つかりませんでした', 'warning');
+        showToast(automatedRtI18n.t('toast.warning'), automatedRtI18n.t('warnings.noSavedSettings'), 'warning');
     }
 }
 
@@ -325,7 +919,36 @@ async function saveLlmSetup() {
 
         // Save session ID
         currentSessionId = response.data.session_id;
-        
+
+        // Reset cached data
+        requirements = [];
+        adversarialPrompts = [];
+        uploadedDocuments = [];
+        evaluationSummary = null;
+        progressState.total = 0;
+        progressState.completed = 0;
+        progressState.estimatedSeconds = null;
+
+        renderUploadedDocuments();
+        renderRequirementsTable();
+        renderAdversarialPromptsTable();
+        renderEvaluationSummary();
+        updateProgressLabel();
+        updateEstimatedTime();
+
+        const progressBar = document.querySelector('#evaluationProgress .progress-bar');
+        if (progressBar) {
+            progressBar.style.width = '0%';
+            progressBar.setAttribute('aria-valuenow', '0');
+            progressBar.textContent = '0%';
+        }
+        const completedPromptsElement = document.getElementById('completedPrompts');
+        const totalPromptsElement = document.getElementById('totalPrompts');
+        if (completedPromptsElement) completedPromptsElement.textContent = '0';
+        if (totalPromptsElement) totalPromptsElement.textContent = '0';
+        const evaluationProgress = document.getElementById('evaluationProgress');
+        if (evaluationProgress) evaluationProgress.style.display = 'none';
+
         // Close modal
         const modal = bootstrap.Modal.getInstance(document.getElementById('llmSetupModal'));
         modal.hide();
@@ -341,10 +964,16 @@ async function saveLlmSetup() {
         // Update navigation buttons
         updateNavigationButtons();
         
-        showToast('成功', 'LLM設定が保存されました', 'success');
+        showToast(automatedRtI18n.t('toast.success'), automatedRtI18n.t('alerts.llmSaved'), 'success');
     } catch (error) {
         console.error('LLM設定保存エラー:', error);
-        showToast('エラー', `LLM設定の保存に失敗しました: ${error.response?.data?.detail || error.message}`, 'danger');
+        showToast(
+            automatedRtI18n.t('toast.error'),
+            automatedRtI18n.t('errors.llmSaveFailed', {
+                error: error.response?.data?.detail || error.message,
+            }),
+            'danger'
+        );
     }
 }
 
@@ -353,13 +982,13 @@ async function saveLlmSetup() {
  */
 async function uploadDocument() {
     if (!currentSessionId) {
-        showToast('エラー', 'まずLLM設定を行ってください', 'danger');
+        showToast(automatedRtI18n.t('toast.error'), automatedRtI18n.t('warnings.runLlmSetupFirst'), 'danger');
         return;
     }
     
     const fileInput = document.getElementById('documentFile');
     if (!fileInput.files || fileInput.files.length === 0) {
-        showToast('警告', 'ファイルが選択されていません', 'warning');
+        showToast(automatedRtI18n.t('toast.warning'), automatedRtI18n.t('warnings.noFileSelected'), 'warning');
         return;
     }
     
@@ -374,22 +1003,25 @@ async function uploadDocument() {
         });
         
         // Add to uploaded document list
-        const documentsList = document.getElementById('uploadedDocuments');
-        const listItem = document.createElement('li');
-        listItem.className = 'list-group-item';
-        listItem.innerHTML = `
-            <strong>${response.data.filename}</strong>
-            <small class="d-block text-muted">テキストプレビュー: ${response.data.text_preview}</small>
-        `;
-        documentsList.appendChild(listItem);
-        
+        uploadedDocuments.push({
+            filename: response.data.filename,
+            preview: response.data.text_preview || '',
+        });
+        renderUploadedDocuments();
+
         // Clear file input
         fileInput.value = '';
         
-        showToast('成功', 'ドキュメントがアップロードされました', 'success');
+        showToast(automatedRtI18n.t('toast.success'), automatedRtI18n.t('alerts.documentUploaded'), 'success');
     } catch (error) {
         console.error('ドキュメントアップロードエラー:', error);
-        showToast('エラー', `ドキュメントのアップロードに失敗しました: ${error.response?.data?.detail || error.message}`, 'danger');
+        showToast(
+            automatedRtI18n.t('toast.error'),
+            automatedRtI18n.t('errors.documentUploadFailed', {
+                error: error.response?.data?.detail || error.message,
+            }),
+            'danger'
+        );
     }
 }
 
@@ -398,7 +1030,7 @@ async function uploadDocument() {
  */
 async function generateRequirements() {
     if (!currentSessionId) {
-        showToast('エラー', 'まずLLM設定を行ってください', 'danger');
+        showToast(automatedRtI18n.t('toast.error'), automatedRtI18n.t('warnings.runLlmSetupFirst'), 'danger');
         return;
     }
     
@@ -411,9 +1043,10 @@ async function generateRequirements() {
     
     // Display while generation
     const submitButton = document.querySelector('#requirementsForm button[type="submit"]');
-    const originalButtonText = submitButton.innerHTML;
+    const originalButtonKey = submitButton.getAttribute('data-i18n');
+    const originalButtonText = originalButtonKey ? automatedRtI18n.t(originalButtonKey) : submitButton.innerHTML;
     submitButton.disabled = true;
-    submitButton.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> 生成中...';
+    submitButton.innerHTML = automatedRtI18n.t('buttons.generating');
     
     try {
         console.log('要件生成リクエスト送信...');
@@ -428,7 +1061,11 @@ async function generateRequirements() {
         
         // Check errors
         if (response.data.error) {
-            showToast('エラー', `要件の生成中にエラーが発生しました: ${response.data.error}`, 'danger');
+            showToast(
+                automatedRtI18n.t('toast.error'),
+                automatedRtI18n.t('errors.requirementsProcessingError', { error: response.data.error }),
+                'danger'
+            );
             console.error('APIレスポンスエラー:', response.data);
             
             // Display error details
@@ -436,7 +1073,7 @@ async function generateRequirements() {
                 const errorDetails = document.createElement('div');
                 errorDetails.className = 'alert alert-danger mt-3';
                 errorDetails.innerHTML = `
-                    <h5>エラー詳細:</h5>
+                    <h5>${automatedRtI18n.t('misc.errorDetails')}</h5>
                     <pre>${response.data.raw_response}</pre>
                 `;
                 document.getElementById('requirementsForm').appendChild(errorDetails);
@@ -446,37 +1083,20 @@ async function generateRequirements() {
         
         // Save requirements
         if (!response.data.requirements) {
-            showToast('エラー', 'サーバーからの応答に要件データがありません', 'danger');
+            showToast(automatedRtI18n.t('toast.error'), automatedRtI18n.t('errors.requirementsMissing'), 'danger');
             console.error('要件データが見つかりません:', response.data);
             return;
         }
         
-        requirements = response.data.requirements;
+        requirements = response.data.requirements || [];
         
-        // Display on requirement table
-        const requirementsTable = document.getElementById('requirementsTable');
-        requirementsTable.innerHTML = '';
-        
+        renderRequirementsTable();
+
         if (requirements.length > 0) {
-            requirements.forEach(req => {
-                const row = document.createElement('tr');
-                row.innerHTML = `
-                    <td>${req.category || '未分類'}</td>
-                    <td>${req.requirement || '説明なし'}</td>
-                    <td>${req.rationale || '-'}</td>
-                `;
-                requirementsTable.appendChild(row);
-            });
-            
-            // Display results
-            document.getElementById('requirementsResult').style.display = 'block';
-            
-            // Update navigation buttons
             updateNavigationButtons();
-            
-            showToast('成功', '要件が生成されました', 'success');
+            showToast(automatedRtI18n.t('toast.success'), automatedRtI18n.t('alerts.requirementsGenerated'), 'success');
         } else {
-            showToast('警告', '生成された要件がありません。別のLLMプロバイダーを試してみてください。', 'warning');
+            showToast(automatedRtI18n.t('toast.warning'), automatedRtI18n.t('alerts.noRequirementsGenerated'), 'warning');
         }
     } catch (error) {
         console.error('要件生成エラー:', error);
@@ -488,29 +1108,40 @@ async function generateRequirements() {
             console.error('データ:', error.response.data);
             console.error('ヘッダー:', error.response.headers);
             
-            showToast('エラー', `要件の生成に失敗しました: ${error.response.status} ${error.response.statusText}`, 'danger');
+            showToast(
+                automatedRtI18n.t('toast.error'),
+                automatedRtI18n.t('errors.requirementsGenerationFailed', {
+                    status: error.response.status,
+                    statusText: error.response.statusText,
+                }),
+                'danger'
+            );
             
             // Display error details
             const errorDetails = document.createElement('div');
             errorDetails.className = 'alert alert-danger mt-3';
             errorDetails.innerHTML = `
-                <h5>エラー詳細:</h5>
-                <p>ステータス: ${error.response.status}</p>
-                <p>メッセージ: ${error.response.statusText}</p>
+                <h5>${automatedRtI18n.t('misc.errorDetails')}</h5>
+                <p>${automatedRtI18n.t('misc.statusLabel')} ${error.response.status}</p>
+                <p>${automatedRtI18n.t('misc.messageLabel')} ${error.response.statusText}</p>
                 <pre>${JSON.stringify(error.response.data, null, 2)}</pre>
             `;
             document.getElementById('requirementsForm').appendChild(errorDetails);
         } else if (error.request) {
             console.error('リクエストエラー:', error.request);
-            showToast('エラー', '要件の生成リクエストに対する応答がありませんでした。ネットワーク接続を確認してください。', 'danger');
+            showToast(automatedRtI18n.t('toast.error'), automatedRtI18n.t('errors.requirementsRequestNoResponse'), 'danger');
         } else {
             console.error('その他のエラー:', error.message);
-            showToast('エラー', `要件の生成処理中にエラーが発生しました: ${error.message}`, 'danger');
+            showToast(
+                automatedRtI18n.t('toast.error'),
+                automatedRtI18n.t('errors.requirementsProcessingError', { error: error.message }),
+                'danger'
+            );
         }
     } finally {
         // Reset button
         submitButton.disabled = false;
-        submitButton.innerHTML = originalButtonText;
+        submitButton.innerHTML = originalButtonKey ? automatedRtI18n.t(originalButtonKey) : originalButtonText;
     }
 }
 
@@ -519,15 +1150,16 @@ async function generateRequirements() {
  */
 async function generateAdversarialPrompts() {
     if (!currentSessionId || requirements.length === 0) {
-        showToast('エラー', 'まず要件を生成してください', 'danger');
+        showToast(automatedRtI18n.t('toast.error'), automatedRtI18n.t('warnings.generateRequirementsFirst'), 'danger');
         return;
     }
     
     // Display while generation
     const submitButton = document.querySelector('#adversarialPromptForm button[type="submit"]');
-    const originalButtonText = submitButton.innerHTML;
+    const originalButtonKey = submitButton.getAttribute('data-i18n');
+    const originalButtonText = originalButtonKey ? automatedRtI18n.t(originalButtonKey) : submitButton.innerHTML;
     submitButton.disabled = true;
-    submitButton.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> 生成中...';
+    submitButton.innerHTML = automatedRtI18n.t('buttons.generating');
     
     try {
         const response = await axios.post('/generate_adversarial_prompts', {
@@ -537,36 +1169,28 @@ async function generateAdversarialPrompts() {
         });
         
         // Save adversarial prompts
-        adversarialPrompts = response.data.adversarial_prompts;
+        adversarialPrompts = response.data.adversarial_prompts || [];
         
         // Display on adversarial prompt table
-        const promptsTable = document.getElementById('adversarialPromptsTable');
-        promptsTable.innerHTML = '';
-        
-        adversarialPrompts.forEach(prompt => {
-            const row = document.createElement('tr');
-            row.innerHTML = `
-                <td>${prompt.category}</td>
-                <td>${prompt.requirement}</td>
-                <td>${prompt.prompt}</td>
-            `;
-            promptsTable.appendChild(row);
-        });
-        
-        // Display results
-        document.getElementById('adversarialPromptsResult').style.display = 'block';
-        
+        renderAdversarialPromptsTable();
+
         // Update navigation buttons
         updateNavigationButtons();
         
-        showToast('成功', '敵対的プロンプトが生成されました', 'success');
+        showToast(automatedRtI18n.t('toast.success'), automatedRtI18n.t('alerts.adversarialGenerated'), 'success');
     } catch (error) {
         console.error('敵対的プロンプト生成エラー:', error);
-        showToast('エラー', `敵対的プロンプトの生成に失敗しました: ${error.response?.data?.detail || error.message}`, 'danger');
+        showToast(
+            automatedRtI18n.t('toast.error'),
+            automatedRtI18n.t('errors.adversarialGenerationFailed', {
+                error: error.response?.data?.detail || error.message,
+            }),
+            'danger'
+        );
     } finally {
         // Reset button
         submitButton.disabled = false;
-        submitButton.innerHTML = originalButtonText;
+        submitButton.innerHTML = originalButtonKey ? automatedRtI18n.t(originalButtonKey) : originalButtonText;
     }
 }
 
@@ -575,7 +1199,7 @@ async function generateAdversarialPrompts() {
  */
 async function exportAdversarialPrompts() {
     if (!currentSessionId || adversarialPrompts.length === 0) {
-        showToast('エラー', 'エクスポートする敵対的プロンプトがありません', 'danger');
+        showToast(automatedRtI18n.t('toast.error'), automatedRtI18n.t('warnings.noAdversarialToExport'), 'danger');
         return;
     }
 
@@ -607,11 +1231,15 @@ async function exportAdversarialPrompts() {
         document.body.removeChild(link);
         window.URL.revokeObjectURL(downloadUrl);
 
-        showToast('成功', '敵対的プロンプトをCSVとしてエクスポートしました', 'success');
+        showToast(automatedRtI18n.t('toast.success'), automatedRtI18n.t('alerts.adversarialExported'), 'success');
     } catch (error) {
         console.error('敵対的プロンプトのエクスポートエラー:', error);
-        const errorMessage = error.response?.data?.detail || error.message || 'エクスポートに失敗しました';
-        showToast('エラー', `敵対的プロンプトのエクスポートに失敗しました: ${errorMessage}`, 'danger');
+        const errorMessage = error.response?.data?.detail || error.message || automatedRtI18n.t('misc.noDescription');
+        showToast(
+            automatedRtI18n.t('toast.error'),
+            automatedRtI18n.t('errors.adversarialExportFailed', { error: errorMessage }),
+            'danger'
+        );
     }
 }
 
@@ -620,15 +1248,16 @@ async function exportAdversarialPrompts() {
  */
 async function runEvaluation() {
     if (!currentSessionId || adversarialPrompts.length === 0) {
-        showToast('エラー', 'まず敵対的プロンプトを生成してください', 'danger');
+        showToast(automatedRtI18n.t('toast.error'), automatedRtI18n.t('warnings.generateAdversarialFirst'), 'danger');
         return;
     }
     
     // Display while evaluation
     const submitButton = document.querySelector('#evaluationForm button[type="submit"]');
-    const originalButtonText = submitButton.innerHTML;
+    const originalButtonKey = submitButton.getAttribute('data-i18n');
+    const originalButtonText = originalButtonKey ? automatedRtI18n.t(originalButtonKey) : submitButton.innerHTML;
     submitButton.disabled = true;
-    submitButton.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> 実行中...';
+    submitButton.innerHTML = automatedRtI18n.t('buttons.running');
     
     // Display progress bar
     document.getElementById('evaluationProgress').style.display = 'block';
@@ -644,6 +1273,11 @@ async function runEvaluation() {
     const completedPromptsElement = document.getElementById('completedPrompts');
     totalPromptsElement.textContent = adversarialPrompts.length;
     completedPromptsElement.textContent = '0';
+    progressState.total = adversarialPrompts.length;
+    progressState.completed = 0;
+    progressState.estimatedSeconds = null;
+    updateProgressLabel();
+    updateEstimatedTime();
     
     // Start time measurement
     const startTime = new Date();
@@ -671,25 +1305,21 @@ async function runEvaluation() {
                 // Update completion count
                 completed = current_index + 1;
                 completedPromptsElement.textContent = completed;
-                
+                progressState.completed = completed;
+                progressState.total = total;
+                updateProgressLabel();
+
                 // Estimate remaining time
-                if (completed > 0) {
+                if (completed > 0 && total > 0) {
                     const elapsedTime = (new Date() - startTime) / 1000; // seconds
                     const timePerPrompt = elapsedTime / completed;
-                    const remainingPrompts = total - completed;
-                    const estimatedTimeRemaining = remainingPrompts * timePerPrompt;
-                    
-                    if (estimatedTimeRemaining > 0) {
-                        let timeString = '';
-                        if (estimatedTimeRemaining > 60) {
-                            const minutes = Math.floor(estimatedTimeRemaining / 60);
-                            const seconds = Math.floor(estimatedTimeRemaining % 60);
-                            timeString = `${minutes}分${seconds}秒`;
-                        } else {
-                            timeString = `${Math.floor(estimatedTimeRemaining)}秒`;
-                        }
-                        estimatedTimeElement.textContent = `推定残り時間: ${timeString}`;
-                    }
+                    const remainingPrompts = Math.max(0, total - completed);
+                    const estimatedTimeRemaining = Math.max(0, remainingPrompts * timePerPrompt);
+                    progressState.estimatedSeconds = estimatedTimeRemaining;
+                    updateEstimatedTime();
+                } else {
+                    progressState.estimatedSeconds = null;
+                    updateEstimatedTime();
                 }
                 
                 // If it is not complete, check again
@@ -697,6 +1327,10 @@ async function runEvaluation() {
                     setTimeout(checkProgress, 1000); // Check every second
                 } else {
                     // Display results when evaluation is complete
+                    progressState.completed = total;
+                    progressState.estimatedSeconds = 0;
+                    updateProgressLabel();
+                    updateEstimatedTime();
                     showEvaluationResults(response.data);
                 }
             } catch (error) {
@@ -712,14 +1346,20 @@ async function runEvaluation() {
         checkProgress();
     } catch (error) {
         console.error('評価実行エラー:', error);
-        showToast('エラー', `評価の実行に失敗しました: ${error.response?.data?.detail || error.message}`, 'danger');
+        showToast(
+            automatedRtI18n.t('toast.error'),
+            automatedRtI18n.t('errors.evaluationFailed', {
+                error: error.response?.data?.detail || error.message,
+            }),
+            'danger'
+        );
         
         // Hide progress bar
         document.getElementById('evaluationProgress').style.display = 'none';
         
         // Reset button
         submitButton.disabled = false;
-        submitButton.innerHTML = originalButtonText;
+        submitButton.innerHTML = originalButtonKey ? automatedRtI18n.t(originalButtonKey) : originalButtonText;
     }
 }
 
@@ -729,47 +1369,22 @@ async function runEvaluation() {
 function showEvaluationResults(data) {
     // Hide progress bar
     document.getElementById('evaluationProgress').style.display = 'none';
-    
-    // Display result summary
-    const summary = data.summary;
-    document.getElementById('totalTests').textContent = summary.total_tests;
-    document.getElementById('passedTests').textContent = summary.passed;
-    document.getElementById('failedTests').textContent = summary.failed;
-    document.getElementById('errorTests').textContent = summary.error;
-    document.getElementById('passRate').textContent = `${summary.pass_rate}%`;
-    
-    // Display statistics by category
-    const categoryStatsDiv = document.getElementById('categoryStats');
-    categoryStatsDiv.innerHTML = '';
-    
-    for (const [category, stats] of Object.entries(summary.category_stats)) {
-        const passRate = stats.total > 0 ? (stats.passed / stats.total * 100).toFixed(2) : 0;
-        const categoryDiv = document.createElement('div');
-        categoryDiv.className = 'mb-3';
-        categoryDiv.innerHTML = `
-            <h6>${category}</h6>
-            <div class="progress">
-                <div class="progress-bar bg-success" role="progressbar" style="width: ${passRate}%;" 
-                    aria-valuenow="${passRate}" aria-valuemin="0" aria-valuemax="100">
-                    ${passRate}% (${stats.passed}/${stats.total})
-                </div>
-            </div>
-        `;
-        categoryStatsDiv.appendChild(categoryDiv);
-    }
-    
-    // Display results
-    document.getElementById('evaluationResult').style.display = 'block';
-    
+
+    evaluationSummary = data.summary || null;
+    renderEvaluationSummary();
+
     // Update navigation buttons
     updateNavigationButtons();
-    
+
     // Reset the execute button
     const submitButton = document.querySelector('#evaluationForm button[type="submit"]');
-    submitButton.disabled = false;
-    submitButton.innerHTML = '評価を実行';
-    
-    showToast('成功', '評価が完了しました', 'success');
+    if (submitButton) {
+        submitButton.disabled = false;
+        const buttonKey = submitButton.getAttribute('data-i18n');
+        submitButton.innerHTML = buttonKey ? automatedRtI18n.t(buttonKey) : automatedRtI18n.t('buttons.runEvaluation');
+    }
+
+    showToast(automatedRtI18n.t('toast.success'), automatedRtI18n.t('alerts.evaluationCompleted'), 'success');
 }
 
 /**
@@ -827,7 +1442,7 @@ function copyLlmSettings(fromPrefix, toPrefix) {
     
     // Note: Do not copy system prompts (because system prompts are settings specific to each LLM)
     
-    showToast('成功', '設定をコピーしました', 'success');
+    showToast(automatedRtI18n.t('toast.success'), automatedRtI18n.t('alerts.settingsCopied'), 'success');
 }
 
 /**

--- a/llm-evaluation-system/automated_rt/templates/index.html
+++ b/llm-evaluation-system/automated_rt/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AIセーフティ評価 自動レッドチーミング</title>
+    <title data-i18n="page.title">AIセーフティ評価 自動レッドチーミング</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/chart.js@3.7.1/dist/chart.min.css">
     <style>
@@ -41,26 +41,32 @@
 </head>
 <body>
     <div class="container mt-4">
-        <h1 class="mb-4 text-center">AIセーフティ評価 自動レッドチーミング</h1>
+        <div class="d-flex justify-content-end mb-3">
+            <div class="btn-group" role="group" aria-label="Language switch">
+                <button type="button" class="btn btn-outline-secondary active" id="langJa" data-lang="ja" data-i18n="language.japanese">日本語</button>
+                <button type="button" class="btn btn-outline-secondary" id="langEn" data-lang="en" data-i18n="language.english">English</button>
+            </div>
+        </div>
+        <h1 class="mb-4 text-center" data-i18n="page.heading">AIセーフティ評価 自動レッドチーミング</h1>
         
         <!-- Current session information -->
         <div class="alert alert-info" id="sessionAlert" style="display: none;">
-            <strong>現在のセッション:</strong> <span id="currentSessionId"></span>
-            <a href="/past_results" class="btn btn-sm btn-primary float-end">過去の評価結果を表示</a>
+            <strong data-i18n="session.current">現在のセッション:</strong> <span id="currentSessionId"></span>
+            <a href="/past_results" class="btn btn-sm btn-primary float-end" data-i18n="session.viewPast">過去の評価結果を表示</a>
         </div>
         
         <!-- Step navigation -->
         <div class="card mb-4" id="stepNavigation" style="display: none;">
             <div class="card-header bg-primary text-white">
-                <h5 class="card-title mb-0">ステップナビゲーション</h5>
+                <h5 class="card-title mb-0" data-i18n="navigation.title">ステップナビゲーション</h5>
             </div>
             <div class="card-body">
                 <div class="btn-group w-100" role="group">
-                    <button type="button" class="btn btn-outline-primary" id="navToStep1" disabled>1. LLM設定</button>
-                    <button type="button" class="btn btn-outline-primary" id="navToStep2" disabled>2. ドキュメント</button>
-                    <button type="button" class="btn btn-outline-primary" id="navToStep3" disabled>3. 要件生成</button>
-                    <button type="button" class="btn btn-outline-primary" id="navToStep4" disabled>4. 敵対的プロンプト</button>
-                    <button type="button" class="btn btn-outline-primary" id="navToStep5" disabled>5. 評価実行</button>
+                    <button type="button" class="btn btn-outline-primary" id="navToStep1" disabled data-i18n="navigation.step1">1. LLM設定</button>
+                    <button type="button" class="btn btn-outline-primary" id="navToStep2" disabled data-i18n="navigation.step2">2. ドキュメント</button>
+                    <button type="button" class="btn btn-outline-primary" id="navToStep3" disabled data-i18n="navigation.step3">3. 要件生成</button>
+                    <button type="button" class="btn btn-outline-primary" id="navToStep4" disabled data-i18n="navigation.step4">4. 敵対的プロンプト</button>
+                    <button type="button" class="btn btn-outline-primary" id="navToStep5" disabled data-i18n="navigation.step5">5. 評価実行</button>
                 </div>
             </div>
         </div>
@@ -69,75 +75,75 @@
         <div class="step-container" id="step1">
             <div class="step-header mb-3">
                 <span class="step-number">1</span>
-                <span class="step-title">LLMの設定</span>
+                <span class="step-title" data-i18n="steps.step1.title">LLMの設定</span>
             </div>
-            <p class="text-muted">評価に使用する各LLMの設定を行います。</p>
-            
+            <p class="text-muted" data-i18n="steps.step1.description">評価に使用する各LLMの設定を行います。</p>
+
             <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#llmSetupModal">
-                LLM設定モーダルを開く
+                <span data-i18n="steps.step1.openModal">LLM設定モーダルを開く</span>
             </button>
         </div>
-        
+
         <!-- Step 2: Upload documents -->
         <div class="step-container" id="step2" style="display: none;">
             <div class="step-header mb-3">
                 <span class="step-number">2</span>
-                <span class="step-title">ドキュメントのアップロード</span>
+                <span class="step-title" data-i18n="steps.step2.title">ドキュメントのアップロード</span>
             </div>
-            <p class="text-muted">ターゲットAIのドメイン情報を含むドキュメントをアップロードします（オプション）。</p>
-            
+            <p class="text-muted" data-i18n="steps.step2.description">ターゲットAIのドメイン情報を含むドキュメントをアップロードします（オプション）。</p>
+
             <form id="documentUploadForm" enctype="multipart/form-data">
                 <div class="mb-3">
-                    <label for="documentFile" class="form-label">ドキュメントファイル（PDF）:</label>
+                    <label for="documentFile" class="form-label" data-i18n="steps.step2.fileLabel">ドキュメントファイル（PDF）:</label>
                     <input type="file" class="form-control" id="documentFile" name="file" accept=".pdf">
                 </div>
-                <button type="submit" class="btn btn-primary">アップロード</button>
+                <button type="submit" class="btn btn-primary" data-i18n="steps.step2.upload">アップロード</button>
             </form>
-            
+
             <div class="mt-3">
-                <h5>アップロード済みドキュメント:</h5>
+                <h5 data-i18n="steps.step2.uploaded">アップロード済みドキュメント:</h5>
                 <ul id="uploadedDocuments" class="list-group">
                     <!-- A list of uploaded documents will be displayed here -->
                 </ul>
             </div>
-            
-            <button class="btn btn-success mt-3" id="continueToStep3">次のステップへ進む</button>
+
+            <button class="btn btn-success mt-3" id="continueToStep3" data-i18n="steps.next">次のステップへ進む</button>
         </div>
-        
+
         <!-- Step 3: Generate requirements -->
         <div class="step-container" id="step3" style="display: none;">
             <div class="step-header mb-3">
                 <span class="step-number">3</span>
-                <span class="step-title">要件の生成</span>
+                <span class="step-title" data-i18n="steps.step3.title">要件の生成</span>
             </div>
-            <p class="text-muted">ターゲットAIが満たすべき安全要件を生成します。</p>
-            
+            <p class="text-muted" data-i18n="steps.step3.description">ターゲットAIが満たすべき安全要件を生成します。</p>
+
             <form id="requirementsForm">
                 <div class="mb-3">
-                    <label for="targetPurpose" class="form-label">ターゲットAIの使用目的:</label>
-                    <textarea class="form-control" id="targetPurpose" rows="3"></textarea>
-                    <small class="text-muted">例: このLLMは顧客サポートチャットボットとして使用され、製品情報の提供や一般的な質問に回答します。</small>
+                    <label for="targetPurpose" class="form-label" data-i18n="steps.step3.purposeLabel">ターゲットAIの使用目的:</label>
+                    <textarea class="form-control" id="targetPurpose" rows="3" data-i18n-placeholder="steps.step3.purposePlaceholder"></textarea>
+                    <small class="text-muted" data-i18n="steps.step3.purposeExample">例: このLLMは顧客サポートチャットボットとして使用され、製品情報の提供や一般的な質問に回答します。</small>
                 </div>
                 <div class="mb-3">
-                    <label for="numRequirements" class="form-label">生成する要件の数:</label>
+                    <label for="numRequirements" class="form-label" data-i18n="steps.step3.countLabel">生成する要件の数:</label>
                     <input type="number" class="form-control" id="numRequirements" min="1" max="100" value="10">
                 </div>
                 <div class="mb-3 form-check">
                     <input type="checkbox" class="form-check-input" id="useDocuments" checked>
-                    <label class="form-check-label" for="useDocuments">アップロードしたドキュメントを使用する</label>
+                    <label class="form-check-label" for="useDocuments" data-i18n="steps.step3.useDocuments">アップロードしたドキュメントを使用する</label>
                 </div>
-                <button type="submit" class="btn btn-primary">要件を生成</button>
+                <button type="submit" class="btn btn-primary" data-i18n="steps.step3.generate">要件を生成</button>
             </form>
-            
+
             <div class="mt-3" id="requirementsResult" style="display: none;">
-                <h5>生成された要件:</h5>
+                <h5 data-i18n="steps.step3.generatedTitle">生成された要件:</h5>
                 <div class="table-responsive">
                     <table class="table table-hover">
                         <thead>
                             <tr>
-                                <th>カテゴリ</th>
-                                <th>要件</th>
-                                <th>理由</th>
+                                <th data-i18n="tables.requirements.category">カテゴリ</th>
+                                <th data-i18n="tables.requirements.requirement">要件</th>
+                                <th data-i18n="tables.requirements.reason">理由</th>
                             </tr>
                         </thead>
                         <tbody id="requirementsTable">
@@ -145,35 +151,35 @@
                         </tbody>
                     </table>
                 </div>
-                <button class="btn btn-success mt-3" id="continueToStep4">次のステップへ進む</button>
+                <button class="btn btn-success mt-3" id="continueToStep4" data-i18n="steps.next">次のステップへ進む</button>
             </div>
         </div>
-        
+
         <!-- Step 4: Generate adversarial prompts -->
         <div class="step-container" id="step4" style="display: none;">
             <div class="step-header mb-3">
                 <span class="step-number">4</span>
-                <span class="step-title">敵対的プロンプトの生成</span>
+                <span class="step-title" data-i18n="steps.step4.title">敵対的プロンプトの生成</span>
             </div>
-            <p class="text-muted">各要件に対する敵対的プロンプトを生成します。</p>
-            
+            <p class="text-muted" data-i18n="steps.step4.description">各要件に対する敵対的プロンプトを生成します。</p>
+
             <form id="adversarialPromptForm">
                 <div class="mb-3">
-                    <label for="promptsPerRequirement" class="form-label">要件ごとに生成するプロンプト数:</label>
+                    <label for="promptsPerRequirement" class="form-label" data-i18n="steps.step4.countLabel">要件ごとに生成するプロンプト数:</label>
                     <input type="number" class="form-control" id="promptsPerRequirement" min="1" max="10" value="3">
                 </div>
-                <button type="submit" class="btn btn-primary">敵対的プロンプトを生成</button>
+                <button type="submit" class="btn btn-primary" data-i18n="steps.step4.generate">敵対的プロンプトを生成</button>
             </form>
-            
+
             <div class="mt-3" id="adversarialPromptsResult" style="display: none;">
-                <h5>生成された敵対的プロンプト:</h5>
+                <h5 data-i18n="steps.step4.generatedTitle">生成された敵対的プロンプト:</h5>
                 <div class="table-responsive">
                     <table class="table table-hover">
                         <thead>
                             <tr>
-                                <th>カテゴリ</th>
-                                <th>要件</th>
-                                <th>敵対的プロンプト</th>
+                                <th data-i18n="tables.adversarial.category">カテゴリ</th>
+                                <th data-i18n="tables.adversarial.requirement">要件</th>
+                                <th data-i18n="tables.adversarial.prompt">敵対的プロンプト</th>
                             </tr>
                         </thead>
                         <tbody id="adversarialPromptsTable">
@@ -181,48 +187,48 @@
                         </tbody>
                     </table>
                 </div>
-                <button class="btn btn-outline-secondary mt-3 me-2" id="exportAdversarialPrompts">生成結果をエクスポート</button>
-                <button class="btn btn-success mt-3" id="continueToStep5">次のステップへ進む</button>
+                <button class="btn btn-outline-secondary mt-3 me-2" id="exportAdversarialPrompts" data-i18n="steps.step4.export">生成結果をエクスポート</button>
+                <button class="btn btn-success mt-3" id="continueToStep5" data-i18n="steps.next">次のステップへ進む</button>
             </div>
         </div>
-        
+
         <!-- Step 5: Execute evaluation -->
         <div class="step-container" id="step5" style="display: none;">
             <div class="step-header mb-3">
                 <span class="step-number">5</span>
-                <span class="step-title">評価の実行</span>
+                <span class="step-title" data-i18n="steps.step5.title">評価の実行</span>
             </div>
-            <p class="text-muted">ターゲットAIに対して敵対的プロンプトを実行し、応答を評価します。</p>
-            
+            <p class="text-muted" data-i18n="steps.step5.description">ターゲットAIに対して敵対的プロンプトを実行し、応答を評価します。</p>
+
             <form id="evaluationForm">
-                <button type="submit" class="btn btn-danger">評価を実行</button>
+                <button type="submit" class="btn btn-danger" data-i18n="steps.step5.run">評価を実行</button>
             </form>
             
             <div class="mt-3" id="evaluationProgress" style="display: none;">
                 <div class="progress mb-2">
                     <div class="progress-bar" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div>
                 </div>
-                <p class="text-center">進捗状況: <span id="completedPrompts">0</span> / <span id="totalPrompts">0</span> プロンプト完了</p>
+                <p class="text-center" data-i18n-progress="evaluation.progress">進捗状況: <span id="completedPrompts">0</span> / <span id="totalPrompts">0</span> プロンプト完了</p>
                 <p class="text-center" id="estimatedTimeRemaining"></p>
             </div>
-            
+
             <div class="mt-3" id="evaluationResult" style="display: none;">
                 <div class="alert alert-success">
-                    <h5>評価サマリー:</h5>
-                    <p>総テスト数: <span id="totalTests">0</span></p>
-                    <p>合格: <span id="passedTests">0</span> (<span id="passRate">0%</span>)</p>
-                    <p>不合格: <span id="failedTests">0</span></p>
-                    <p>エラー: <span id="errorTests">0</span></p>
+                    <h5 data-i18n="evaluation.summary">評価サマリー:</h5>
+                    <p><span data-i18n="evaluation.totalLabel">総テスト数:</span> <span id="totalTests">0</span></p>
+                    <p><span data-i18n="evaluation.passedLabel">合格:</span> <span id="passedTests">0</span> (<span id="passRate">0%</span>)</p>
+                    <p><span data-i18n="evaluation.failedLabel">不合格:</span> <span id="failedTests">0</span></p>
+                    <p><span data-i18n="evaluation.errorLabel">エラー:</span> <span id="errorTests">0</span></p>
                 </div>
-                
+
                 <div class="mt-3">
-                    <h5>カテゴリ別結果:</h5>
+                    <h5 data-i18n="evaluation.categoryResults">カテゴリ別結果:</h5>
                     <div id="categoryStats">
                         <!-- Category statistics are displayed here -->
                     </div>
                 </div>
-                
-                <button class="btn btn-primary mt-3" id="viewDetailedResults">詳細結果を表示</button>
+
+                <button class="btn btn-primary mt-3" id="viewDetailedResults" data-i18n="evaluation.viewDetails">詳細結果を表示</button>
             </div>
         </div>
         
@@ -592,15 +598,26 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@3.7.1/dist/chart.min.js"></script>
+    <script src="/static/js/i18n.js"></script>
     <script src="/static/js/main.js"></script>
     <script type="text/javascript">
 document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('[data-lang]').forEach(function(button) {
+        button.addEventListener('click', function() {
+            automatedRtI18n.setLanguage(button.dataset.lang);
+        });
+    });
+
     // Automatically load settings saved when the page is loaded
     if (localStorage.getItem('llmSettings')) {
         try {
             const settings = JSON.parse(localStorage.getItem('llmSettings'));
             applyLlmSettings(settings);
-            showToast('情報', '保存済みの設定を読み込みました', 'info');
+            showToast(
+                automatedRtI18n.t('toast.info'),
+                automatedRtI18n.t('alerts.settingsLoaded'),
+                'info'
+            );
         } catch (error) {
             console.error('設定の自動読み込みエラー:', error);
         }

--- a/llm-evaluation-system/automated_rt/templates/past_results.html
+++ b/llm-evaluation-system/automated_rt/templates/past_results.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>過去の評価結果 - AIセーフティ評価 自動レッドチーミング</title>
+    <title data-i18n="page.title">過去の評価結果 - AIセーフティ評価 自動レッドチーミング</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <style>
         /* Japanese font settings */
@@ -21,12 +21,19 @@
 </head>
 <body>
     <div class="container mt-4">
-        <h1 class="mb-4">過去の評価結果</h1>
-        
-        <div class="mb-4">
-            <a href="/" class="btn btn-primary">ホームに戻る</a>
+        <div class="d-flex justify-content-end mb-3">
+            <div class="btn-group" role="group" aria-label="Language switch">
+                <button type="button" class="btn btn-outline-secondary active" data-lang="ja" data-i18n="language.japanese">日本語</button>
+                <button type="button" class="btn btn-outline-secondary" data-lang="en" data-i18n="language.english">English</button>
+            </div>
         </div>
-        
+
+        <h1 class="mb-4" data-i18n="page.heading">過去の評価結果</h1>
+
+        <div class="mb-4">
+            <a href="/" class="btn btn-primary" data-i18n="buttons.backHome">ホームに戻る</a>
+        </div>
+
         {% if result_files %}
             <div class="row">
                 {% for file in result_files %}
@@ -36,42 +43,42 @@
                                 <h5 class="card-title mb-0">{{ file.human_date }}</h5>
                             </div>
                             <div class="card-body">
-                                <p><strong>ファイルサイズ:</strong> {{ file.file_size }} KB</p>
-                                <p><strong>セッションID:</strong> {{ file.session_id[:8] }}...</p>
-                                
+                                <p><strong data-i18n="cards.fileSizeLabel">ファイルサイズ:</strong> {{ file.file_size }} KB</p>
+                                <p><strong data-i18n="cards.sessionIdLabel">セッションID:</strong> {{ file.session_id[:8] }}...</p>
+
                                 <div class="card mb-3">
                                     <div class="card-header bg-light">
-                                        <h6 class="mb-0">評価サマリー</h6>
+                                        <h6 class="mb-0" data-i18n="cards.summaryHeading">評価サマリー</h6>
                                     </div>
                                     <div class="card-body">
                                         <div class="row">
                                             <div class="col-4 text-center">
                                                 <h5>{{ file.summary.total }}</h5>
-                                                <small class="text-muted">テスト数</small>
+                                                <small class="text-muted" data-i18n="cards.totalTests">テスト数</small>
                                             </div>
                                             <div class="col-4 text-center text-success">
                                                 <h5>{{ file.summary.passed }}</h5>
-                                                <small class="text-muted">合格</small>
+                                                <small class="text-muted" data-i18n="cards.passed">合格</small>
                                             </div>
                                             <div class="col-4 text-center text-danger">
                                                 <h5>{{ file.summary.failed }}</h5>
-                                                <small class="text-muted">不合格</small>
+                                                <small class="text-muted" data-i18n="cards.failed">不合格</small>
                                             </div>
                                         </div>
                                         <div class="progress mt-2">
-                                            <div class="progress-bar bg-success" role="progressbar" style="width: {{ file.summary.pass_rate }}%;" 
+                                            <div class="progress-bar bg-success" role="progressbar" style="width: {{ file.summary.pass_rate }}%;"
                                                 aria-valuenow="{{ file.summary.pass_rate }}" aria-valuemin="0" aria-valuemax="100">
                                                 {{ file.summary.pass_rate }}%
                                             </div>
                                         </div>
                                     </div>
                                 </div>
-                                
+
                                 <!-- Use two separate buttons instead of a drop-down menu -->
                                 <div class="d-grid gap-2">
-                                    <a href="/past_results/{{ file.filename }}" class="btn btn-primary">詳細を表示</a>
-                                    <a href="/export/html/file/{{ file.filename }}" class="btn btn-success">HTML形式でダウンロード</a>
-                                    <a href="/export/csv/file/{{ file.filename }}" class="btn btn-secondary">CSV形式でダウンロード</a>
+                                    <a href="/past_results/{{ file.filename }}" class="btn btn-primary" data-i18n="buttons.viewDetails">詳細を表示</a>
+                                    <a href="/export/html/file/{{ file.filename }}" class="btn btn-success" data-i18n="buttons.downloadHtml">HTML形式でダウンロード</a>
+                                    <a href="/export/csv/file/{{ file.filename }}" class="btn btn-secondary" data-i18n="buttons.downloadCsv">CSV形式でダウンロード</a>
                                 </div>
                             </div>
                         </div>
@@ -79,12 +86,71 @@
                 {% endfor %}
             </div>
         {% else %}
-            <div class="alert alert-info">
+            <div class="alert alert-info" data-i18n="page.noResults">
                 過去の評価結果がありません。評価を実行すると、結果がここに表示されます。
             </div>
         {% endif %}
     </div>
-    
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/static/js/i18n.js"></script>
+    <script>
+        const pastResultsMessages = {
+            ja: {
+                language: { japanese: "日本語", english: "English" },
+                page: {
+                    title: "過去の評価結果 - AIセーフティ評価 自動レッドチーミング",
+                    heading: "過去の評価結果",
+                    noResults: "過去の評価結果がありません。評価を実行すると、結果がここに表示されます。"
+                },
+                buttons: {
+                    backHome: "ホームに戻る",
+                    viewDetails: "詳細を表示",
+                    downloadHtml: "HTML形式でダウンロード",
+                    downloadCsv: "CSV形式でダウンロード"
+                },
+                cards: {
+                    fileSizeLabel: "ファイルサイズ:",
+                    sessionIdLabel: "セッションID:",
+                    summaryHeading: "評価サマリー",
+                    totalTests: "テスト数",
+                    passed: "合格",
+                    failed: "不合格"
+                }
+            },
+            en: {
+                language: { japanese: "Japanese", english: "English" },
+                page: {
+                    title: "Past Evaluation Results - AI Safety Evaluation Automated Red Teaming",
+                    heading: "Past Evaluation Results",
+                    noResults: "No past evaluation results are available. After you run an evaluation, the results will appear here."
+                },
+                buttons: {
+                    backHome: "Back to Home",
+                    viewDetails: "View Details",
+                    downloadHtml: "Download as HTML",
+                    downloadCsv: "Download as CSV"
+                },
+                cards: {
+                    fileSizeLabel: "File size:",
+                    sessionIdLabel: "Session ID:",
+                    summaryHeading: "Evaluation Summary",
+                    totalTests: "Number of tests",
+                    passed: "Passed",
+                    failed: "Failed"
+                }
+            }
+        };
+
+        automatedRtI18n.register({ messages: pastResultsMessages });
+
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('[data-lang]').forEach(function(button) {
+                button.addEventListener('click', function() {
+                    automatedRtI18n.setLanguage(button.dataset.lang);
+                });
+            });
+        });
+    </script>
 </body>
 </html>

--- a/llm-evaluation-system/automated_rt/templates/results.html
+++ b/llm-evaluation-system/automated_rt/templates/results.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>評価結果 - AIセーフティ評価 自動レッドチーミング</title>
+    <title data-i18n="page.title">評価結果 - AIセーフティ評価 自動レッドチーミング</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <style>
         .result-card {
@@ -69,27 +69,32 @@
 </head>
 <body>
     <div class="container mt-4">
-        <h1 class="mb-4">評価結果
-            {% if is_past_result %}
-                <small class="text-muted">(過去の結果: {{ timestamp }})</small>
-            {% endif %}
-        </h1>
+        <div class="d-flex justify-content-end mb-3">
+            <div class="btn-group" role="group" aria-label="Language switch">
+                <button type="button" class="btn btn-outline-secondary active" data-lang="ja" data-i18n="language.japanese">日本語</button>
+                <button type="button" class="btn btn-outline-secondary" data-lang="en" data-i18n="language.english">English</button>
+            </div>
+        </div>
+        <h1 class="mb-4" data-i18n="page.heading">評価結果</h1>
+        {% if is_past_result %}
+            <p class="text-muted" id="pastResultInfo" data-timestamp="{{ timestamp }}" data-i18n="page.pastResult">過去の結果: {{ timestamp }}</p>
+        {% endif %}
         
         <div class="mb-4">
-            <a href="/" class="btn btn-primary me-2">ホームに戻る</a>
-            <a href="/past_results" class="btn btn-secondary me-2">過去の評価結果一覧</a>
-            
+            <a href="/" class="btn btn-primary me-2" data-i18n="buttons.backHome">ホームに戻る</a>
+            <a href="/past_results" class="btn btn-secondary me-2" data-i18n="buttons.pastResults">過去の評価結果一覧</a>
+
             <div class="btn-group">
-                <button type="button" class="btn btn-success dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+                <button type="button" class="btn btn-success dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" data-i18n="buttons.export">
                     エクスポート
                 </button>
                 <ul class="dropdown-menu">
                     {% if is_past_result %}
-                        <li><a class="dropdown-item" href="/export/html/file/{{ filename }}">HTML形式でダウンロード</a></li>
-                        <li><a class="dropdown-item" href="/export/csv/file/{{ filename }}">CSV形式でダウンロード</a></li>
+                        <li><a class="dropdown-item" href="/export/html/file/{{ filename }}" data-i18n="buttons.downloadHtml">HTML形式でダウンロード</a></li>
+                        <li><a class="dropdown-item" href="/export/csv/file/{{ filename }}" data-i18n="buttons.downloadCsv">CSV形式でダウンロード</a></li>
                     {% else %}
-                        <li><a class="dropdown-item" href="/export/html/{{ session_id }}">HTML形式でダウンロード</a></li>
-                        <li><a class="dropdown-item" href="/export/csv/{{ session_id }}">CSV形式でダウンロード</a></li>
+                        <li><a class="dropdown-item" href="/export/html/{{ session_id }}" data-i18n="buttons.downloadHtml">HTML形式でダウンロード</a></li>
+                        <li><a class="dropdown-item" href="/export/csv/{{ session_id }}" data-i18n="buttons.downloadCsv">CSV形式でダウンロード</a></li>
                     {% endif %}
                 </ul>
             </div>
@@ -98,13 +103,13 @@
         <!-- Evaluation summary -->
         <div class="card mb-4">
             <div class="card-header bg-dark text-white">
-                <h5 class="card-title mb-0">評価サマリー</h5>
+                <h5 class="card-title mb-0" data-i18n="summary.heading">評価サマリー</h5>
             </div>
             <div class="card-body">
                 <div class="row">
                     <div class="col-md-3">
                         <div class="card text-white bg-primary mb-3">
-                            <div class="card-header">テスト総数</div>
+                            <div class="card-header" data-i18n="summary.total">テスト総数</div>
                             <div class="card-body">
                                 <h5 class="card-title" id="totalTests">{{ results|length }}</h5>
                             </div>
@@ -112,7 +117,7 @@
                     </div>
                     <div class="col-md-3">
                         <div class="card text-white bg-success mb-3">
-                            <div class="card-header">合格</div>
+                            <div class="card-header" data-i18n="summary.passed">合格</div>
                             <div class="card-body">
                                 <h5 class="card-title" id="passedTests">{{ results|selectattr('evaluation.passed', 'equalto', true)|list|length }}</h5>
                                 {% set not_skipped = results|rejectattr('evaluation.skipped', 'defined')|list|length %}
@@ -126,7 +131,7 @@
                     </div>
                     <div class="col-md-3">
                         <div class="card text-white bg-danger mb-3">
-                            <div class="card-header">不合格</div>
+                            <div class="card-header" data-i18n="summary.failed">不合格</div>
                             <div class="card-body">
                                 <h5 class="card-title" id="failedTests">{{ results|selectattr('evaluation.passed', 'equalto', false)|list|length }}</h5>
                             </div>
@@ -134,7 +139,7 @@
                     </div>
                     <div class="col-md-3">
                         <div class="card text-white bg-secondary mb-3">
-                            <div class="card-header">スキップ</div>
+                            <div class="card-header" data-i18n="summary.skipped">スキップ</div>
                             <div class="card-body">
                                 <h5 class="card-title" id="skippedTests">{{ results|selectattr('evaluation.skipped', 'defined')|list|length }}</h5>
                             </div>
@@ -147,22 +152,22 @@
         <!-- Category filters -->
         <div class="card mb-4">
             <div class="card-header bg-secondary text-white">
-                <h5 class="card-title mb-0">カテゴリフィルター</h5>
+                <h5 class="card-title mb-0" data-i18n="filters.categoryHeading">カテゴリフィルター</h5>
             </div>
             <div class="card-body">
                 <div class="btn-group mb-3" role="group" id="categoryFilters">
-                    <button type="button" class="btn btn-outline-primary active" data-category="all">全て</button>
-                    <button type="button" class="btn btn-outline-primary" data-category="有害情報の出力制御">有害情報の出力制御</button>
-                    <button type="button" class="btn btn-outline-primary" data-category="偽誤情報の出力・誘導の防止">偽誤情報の出力・誘導の防止</button>
-                    <button type="button" class="btn btn-outline-primary" data-category="公平性と包摂性">公平性と包摂性</button>
-                    <button type="button" class="btn btn-outline-primary" data-category="ハイリスク利用・目的外利用への対処">ハイリスク利用・目的外利用への対処</button>
-                    <button type="button" class="btn btn-outline-primary" data-category="プライバシー保護">プライバシー保護</button>
+                    <button type="button" class="btn btn-outline-primary active" data-category="all" data-i18n="filters.all">全て</button>
+                    <button type="button" class="btn btn-outline-primary" data-category="有害情報の出力制御" data-i18n="filters.harmful">有害情報の出力制御</button>
+                    <button type="button" class="btn btn-outline-primary" data-category="偽誤情報の出力・誘導の防止" data-i18n="filters.misinformation">偽誤情報の出力・誘導の防止</button>
+                    <button type="button" class="btn btn-outline-primary" data-category="公平性と包摂性" data-i18n="filters.fairness">公平性と包摂性</button>
+                    <button type="button" class="btn btn-outline-primary" data-category="ハイリスク利用・目的外利用への対処" data-i18n="filters.highRisk">ハイリスク利用・目的外利用への対処</button>
+                    <button type="button" class="btn btn-outline-primary" data-category="プライバシー保護" data-i18n="filters.privacy">プライバシー保護</button>
                 </div>
                 <div class="btn-group" role="group" id="statusFilters">
-                    <button type="button" class="btn btn-outline-secondary active" data-status="all">全てのステータス</button>
-                    <button type="button" class="btn btn-outline-success" data-status="passed">合格</button>
-                    <button type="button" class="btn btn-outline-danger" data-status="failed">不合格</button>
-                    <button type="button" class="btn btn-outline-secondary" data-status="skipped">スキップ</button>
+                    <button type="button" class="btn btn-outline-secondary active" data-status="all" data-i18n="filters.allStatuses">全てのステータス</button>
+                    <button type="button" class="btn btn-outline-success" data-status="passed" data-i18n="filters.statusPassed">合格</button>
+                    <button type="button" class="btn btn-outline-danger" data-status="failed" data-i18n="filters.statusFailed">不合格</button>
+                    <button type="button" class="btn btn-outline-secondary" data-status="skipped" data-i18n="filters.statusSkipped">スキップ</button>
                 </div>
             </div>
         </div>
@@ -178,32 +183,32 @@
                             <span class="category-badge bg-info">{{ result.category }}</span>
                             <span class="evaluation-result {{ status_class }}-text">
                                 {% if result.evaluation.skipped %}
-                                    ⏭️ スキップ
+                                    ⏭️ <span data-i18n="status.skipped">スキップ</span>
                                 {% elif result.evaluation.passed %}
-                                    ✅ 合格
+                                    ✅ <span data-i18n="status.passed">合格</span>
                                 {% else %}
-                                    ❌ 不合格
+                                    ❌ <span data-i18n="status.failed">不合格</span>
                                 {% endif %}
                             </span>
                         </span>
-                        <button class="btn btn-sm btn-outline-primary" type="button" data-bs-toggle="collapse" data-bs-target="#collapse{{ loop.index }}">
+                        <button class="btn btn-sm btn-outline-primary" type="button" data-bs-toggle="collapse" data-bs-target="#collapse{{ loop.index }}" data-i18n="results.details">
                             詳細
                         </button>
                     </div>
                     <div class="card-body">
-                        <h5 class="card-title">要件: {{ result.requirement }}</h5>
+                        <h5 class="card-title"><span data-i18n="results.requirement">要件:</span> {{ result.requirement }}</h5>
                         <div class="collapse" id="collapse{{ loop.index }}">
                             <div class="card-text mt-3">
                                 <div class="mb-3">
-                                    <h6>敵対的プロンプト:</h6>
+                                    <h6 data-i18n="results.adversarialPrompt">敵対的プロンプト:</h6>
                                     <div class="prompt-text">{{ result.prompt }}</div>
                                 </div>
                                 <div class="mb-3">
-                                    <h6>ターゲットAIの応答:</h6>
+                                    <h6 data-i18n="results.targetResponse">ターゲットAIの応答:</h6>
                                     <div class="response-text">{{ result.target_response }}</div>
                                 </div>
                                 <div>
-                                    <h6>評価理由:</h6>
+                                    <h6 data-i18n="results.evaluationReason">評価理由:</h6>
                                     <p>{{ result.evaluation.reason }}</p>
                                 </div>
                             </div>
@@ -215,8 +220,135 @@
     </div>
     
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/static/js/i18n.js"></script>
     <script>
+        const resultsMessages = {
+            ja: {
+                language: { japanese: "日本語", english: "English" },
+                page: {
+                    title: "評価結果 - AIセーフティ評価 自動レッドチーミング",
+                    heading: "評価結果",
+                    pastResult: "過去の結果: {{timestamp}}"
+                },
+                buttons: {
+                    backHome: "ホームに戻る",
+                    pastResults: "過去の評価結果一覧",
+                    export: "エクスポート",
+                    downloadHtml: "HTML形式でダウンロード",
+                    downloadCsv: "CSV形式でダウンロード"
+                },
+                summary: {
+                    heading: "評価サマリー",
+                    total: "テスト総数",
+                    passed: "合格",
+                    failed: "不合格",
+                    skipped: "スキップ"
+                },
+                filters: {
+                    categoryHeading: "カテゴリフィルター",
+                    all: "全て",
+                    harmful: "有害情報の出力制御",
+                    misinformation: "偽誤情報の出力・誘導の防止",
+                    fairness: "公平性と包摂性",
+                    highRisk: "ハイリスク利用・目的外利用への対処",
+                    privacy: "プライバシー保護",
+                    allStatuses: "全てのステータス",
+                    statusPassed: "合格",
+                    statusFailed: "不合格",
+                    statusSkipped: "スキップ"
+                },
+                status: {
+                    skipped: "スキップ",
+                    passed: "合格",
+                    failed: "不合格"
+                },
+                results: {
+                    details: "詳細",
+                    requirement: "要件:",
+                    adversarialPrompt: "敵対的プロンプト:",
+                    targetResponse: "ターゲットAIの応答:",
+                    evaluationReason: "評価理由:"
+                }
+            },
+            en: {
+                language: { japanese: "Japanese", english: "English" },
+                page: {
+                    title: "Evaluation Results - AI Safety Evaluation Automated Red Teaming",
+                    heading: "Evaluation Results",
+                    pastResult: "Past result: {{timestamp}}"
+                },
+                buttons: {
+                    backHome: "Back to Home",
+                    pastResults: "Past Evaluation Results",
+                    export: "Export",
+                    downloadHtml: "Download as HTML",
+                    downloadCsv: "Download as CSV"
+                },
+                summary: {
+                    heading: "Evaluation Summary",
+                    total: "Total Tests",
+                    passed: "Passed",
+                    failed: "Failed",
+                    skipped: "Skipped"
+                },
+                filters: {
+                    categoryHeading: "Category Filters",
+                    all: "All",
+                    harmful: "Control of Harmful Outputs",
+                    misinformation: "Prevent Misinformation",
+                    fairness: "Fairness and Inclusiveness",
+                    highRisk: "High-Risk & Misuse Mitigation",
+                    privacy: "Privacy Protection",
+                    allStatuses: "All Statuses",
+                    statusPassed: "Passed",
+                    statusFailed: "Failed",
+                    statusSkipped: "Skipped"
+                },
+                status: {
+                    skipped: "Skipped",
+                    passed: "Passed",
+                    failed: "Failed"
+                },
+                results: {
+                    details: "Details",
+                    requirement: "Requirement:",
+                    adversarialPrompt: "Adversarial Prompt:",
+                    targetResponse: "Target AI Response:",
+                    evaluationReason: "Evaluation Reason:"
+                }
+            }
+        };
+
+        const resultsTextMap = {
+            "有害情報の出力制御": { ja: "有害情報の出力制御", en: "Control of Harmful Outputs" },
+            "偽誤情報の出力・誘導の防止": { ja: "偽誤情報の出力・誘導の防止", en: "Prevent Misinformation" },
+            "公平性と包摂性": { ja: "公平性と包摂性", en: "Fairness and Inclusiveness" },
+            "ハイリスク利用・目的外利用への対処": { ja: "ハイリスク利用・目的外利用への対処", en: "High-Risk & Misuse Mitigation" },
+            "プライバシー保護": { ja: "プライバシー保護", en: "Privacy Protection" }
+        };
+
+        function updatePastResultInfo() {
+            const pastResultElement = document.getElementById('pastResultInfo');
+            if (!pastResultElement) return;
+            const timestamp = pastResultElement.dataset.timestamp;
+            pastResultElement.textContent = automatedRtI18n.t('page.pastResult', { timestamp });
+        }
+
+        automatedRtI18n.register({
+            messages: resultsMessages,
+            textMap: resultsTextMap,
+            onLanguageChange: [updatePastResultInfo]
+        });
+
         document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('[data-lang]').forEach(function(button) {
+                button.addEventListener('click', function() {
+                    automatedRtI18n.setLanguage(button.dataset.lang);
+                });
+            });
+
+            updatePastResultInfo();
+
             // Category filter
             const categoryButtons = document.querySelectorAll('#categoryFilters button');
             categoryButtons.forEach(button => {


### PR DESCRIPTION
## Summary
- add lightweight i18n helper to the automated red teaming frontend and wire it into the existing JS workflow
- internationalize the index, results, and past results pages with language toggles and translated strings
- ensure dynamic content such as tables, evaluation stats, and uploaded document previews re-render in the selected language

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68eda6e820b88332b591df69f78982a3