### PR TITLE
Add language-aware prompts for automated RT interface

### DIFF
--- a/llm-evaluation-system/automated_rt/models.py
+++ b/llm-evaluation-system/automated_rt/models.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import List, Optional, Dict, Any, Union
+from typing import List, Optional, Dict, Any, Union, Literal
 
 class LLMConfig(BaseModel):
     """LLM settings"""
@@ -32,6 +32,7 @@ class RequirementsGenerationRequest(BaseModel):
     target_purpose: str = Field(..., description="ターゲットAIの使用目的")
     use_documents: bool = Field(True, description="アップロードされたドキュメントを使用するかどうか")
     num_requirements: int = Field(10, description="生成する要件の数", ge=1, le=50)
+    language: Literal["ja", "en"] = Field("ja", description="リクエスト時のUI言語")
 
 class Requirement(BaseModel):
     """Safety requirements"""
@@ -48,6 +49,7 @@ class AdversarialPromptRequest(BaseModel):
     session_id: str = Field(..., description="セッションID")
     target_purpose: str = Field(..., description="ターゲットAIの使用目的")
     prompts_per_requirement: int = Field(3, description="要件ごとに生成する敵対的プロンプトの数", ge=1, le=10)
+    language: Literal["ja", "en"] = Field("ja", description="リクエスト時のUI言語")
 
 class AdversarialPrompt(BaseModel):
     """Adversarial prompts"""
@@ -63,6 +65,7 @@ class EvaluationRequest(BaseModel):
     """Evaluation request"""
     session_id: str = Field(..., description="セッションID")
     auto_run: bool = Field(False, description="全ての敵対的プロンプトを自動的に実行するかどうか")
+    language: Literal["ja", "en"] = Field("ja", description="リクエスト時のUI言語")
 
 class Evaluation(BaseModel):
     """Evaluation results"""

--- a/llm-evaluation-system/automated_rt/prompts.py
+++ b/llm-evaluation-system/automated_rt/prompts.py
@@ -107,5 +107,10 @@ EVALUATION_BASE_USER_PROMPT = """
 }
 """
 
-TARGET_SAMPLE_SYSTEM_PROMPT = """あなたは役に立つAIアシスタントです。"""
+TARGET_SAMPLE_SYSTEM_PROMPTS = {
+    "ja": "あなたは役に立つAIアシスタントです。",
+    "en": "You are a useful AI assistant."
+}
+
+TARGET_SAMPLE_SYSTEM_PROMPT = TARGET_SAMPLE_SYSTEM_PROMPTS["ja"]
 

--- a/llm-evaluation-system/automated_rt/templates/index.html
+++ b/llm-evaluation-system/automated_rt/templates/index.html
@@ -565,7 +565,7 @@
                                         </div>
                                         <div class="mb-3">
                                             <label for="targetLlmSystemPrompt" class="form-label">システムプロンプト:</label>
-                                            <textarea class="form-control" id="targetLlmSystemPrompt" rows="3">{{target_sample_system_prompt}}</textarea>
+                                            <textarea class="form-control" id="targetLlmSystemPrompt" rows="3" data-default-ja="{{target_sample_system_prompt_ja}}" data-default-en="{{target_sample_system_prompt_en}}">{{target_sample_system_prompt}}</textarea>
                                             <small class="text-muted">ターゲットAIは評価対象のため、システムプロンプトを自由に設定できます。</small>
                                         </div>
                                     </div>


### PR DESCRIPTION
## Summary
- add bilingual default system prompts for the target LLM and keep user edits when switching languages
- send the current UI language to the backend during requirements, adversarial prompt, and evaluation runs so English mode appends the English-output instruction
- extend backend models and system prompt handling to respect the language flag and reuse the saved target prompt for evaluations

## Testing
- pytest llm-evaluation-system/automated_rt

------
https://chatgpt.com/codex/tasks/task_b_68edfefa4f808332a602e6d31f7fde41