### PR TITLE
Improve automated RT progress tracking granularity

### DIFF
--- a/llm-evaluation-system/automated_rt/app.py
+++ b/llm-evaluation-system/automated_rt/app.py
@@ -474,12 +474,55 @@ async def evaluate_target_llm(request: EvaluationRequest):
     eval_llm = _create_llm_client(session["evaluation_llm"])
     
     results = []
-    total_prompts = len(session["adversarial_prompts"])
-    
+    prompts = session["adversarial_prompts"]
+    total_prompts = len(prompts)
+
+    prompt_step_counts = [1 if prompt.get("error", False) else 3 for prompt in prompts]
+    total_steps = sum(prompt_step_counts)
+
+    session["evaluation_progress"] = {
+        "total_steps": total_steps,
+        "completed_steps": 0,
+        "completed_prompts": 0,
+        "total_prompts": total_prompts,
+        "current_prompt_index": None,
+        "current_step_description": None,
+        "last_update": datetime.now().isoformat(),
+    }
+
+    def record_progress(step_increment=0, prompt_index=None, description=None, prompt_completed=False):
+        progress = session.get("evaluation_progress")
+        if not progress:
+            return
+
+        total_steps_local = progress.get("total_steps") or 0
+        completed_steps_local = progress.get("completed_steps") or 0
+
+        if step_increment:
+            if total_steps_local > 0:
+                progress["completed_steps"] = min(completed_steps_local + step_increment, total_steps_local)
+            else:
+                progress["completed_steps"] = completed_steps_local + step_increment
+
+        if prompt_index is not None:
+            progress["current_prompt_index"] = prompt_index
+
+        if description is not None:
+            progress["current_step_description"] = description
+
+        if prompt_completed:
+            if prompt_index is not None:
+                progress["completed_prompts"] = max(progress.get("completed_prompts", 0), prompt_index + 1)
+            else:
+                progress["completed_prompts"] = progress.get("total_prompts", progress.get("completed_prompts", 0))
+
+        progress["last_update"] = datetime.now().isoformat()
+
     # Test target AI with each adversarial prompt
-    for i, prompt_data in enumerate(session["adversarial_prompts"]):
+    for i, prompt_data in enumerate(prompts):
+        record_progress(prompt_index=i, description="preparing_prompt")
         adversarial_prompt = prompt_data["prompt"]
-        
+
         # Fixed: Prompts with error flags will be skipped
         if prompt_data.get("error", False):
             logger.info(f"プロンプト {i+1}/{total_prompts} はエラーフラグがありスキップします: {adversarial_prompt[:50]}...")
@@ -497,21 +540,32 @@ async def evaluate_target_llm(request: EvaluationRequest):
                 }
             }
             results.append(result)
+            record_progress(
+                step_increment=prompt_step_counts[i],
+                prompt_index=i,
+                description="skipped_prompt",
+                prompt_completed=True
+            )
             continue
-        
+
         logger.info(f"プロンプト {i+1}/{total_prompts} を評価中: {adversarial_prompt[:50]}...")
-        
+
         # Send adversarial prompts to target AI
         target_system_prompt = session["target_llm"].system_prompt
         if not target_system_prompt:
             target_system_prompt = TARGET_SAMPLE_SYSTEM_PROMPTS.get(language, TARGET_SAMPLE_SYSTEM_PROMPTS["ja"])
         target_system_prompt = _append_english_output_note(target_system_prompt, language)
 
-        target_response = await target_llm.generate(target_system_prompt, adversarial_prompt)
-        
+        record_progress(prompt_index=i, description="request_target_llm")
+        target_response = ""
+        try:
+            target_response = await target_llm.generate(target_system_prompt, adversarial_prompt)
+        finally:
+            record_progress(step_increment=1, prompt_index=i, description="target_response_received")
+
         # Preparing system prompts (base prompts + user custom prompts)
         base_system_prompt = EVALUATION_BASE_SYSTEM_PROMPT
-        
+
         # Add user custom prompts if available
         custom_prompt = session["evaluation_llm"].system_prompt
         if custom_prompt:
@@ -520,12 +574,17 @@ async def evaluate_target_llm(request: EvaluationRequest):
             system_prompt = base_system_prompt
 
         system_prompt = _append_english_output_note(system_prompt, language)
-        
+
         user_prompt = EVALUATION_BASE_USER_PROMPT % {"category": prompt_data["category"], "requirement": prompt_data["requirement"], "adversarial": adversarial_prompt, "response": target_response}
-        
+
         try:
-            eval_response = await eval_llm.generate(system_prompt, user_prompt)
-            
+            record_progress(prompt_index=i, description="request_evaluation_llm")
+            eval_response = ""
+            try:
+                eval_response = await eval_llm.generate(system_prompt, user_prompt)
+            finally:
+                record_progress(step_increment=1, prompt_index=i, description="evaluation_response_received")
+
             try:
                 # Parse JSON response
                 try:
@@ -570,6 +629,7 @@ async def evaluate_target_llm(request: EvaluationRequest):
                     "evaluation": evaluation
                 }
                 results.append(result)
+                record_progress(step_increment=1, prompt_index=i, description="prompt_completed", prompt_completed=True)
             except json.JSONDecodeError as e:
                 # If JSON parsing fails
                 print(f"評価レスポンスのパースに失敗: {e}")
@@ -586,6 +646,7 @@ async def evaluate_target_llm(request: EvaluationRequest):
                     }
                 }
                 results.append(result)
+                record_progress(step_increment=1, prompt_index=i, description="prompt_completed_with_parse_error", prompt_completed=True)
         except Exception as e:
             print(f"評価中のエラー: {e}")
             result = {
@@ -600,10 +661,11 @@ async def evaluate_target_llm(request: EvaluationRequest):
                 }
             }
             results.append(result)
-    
+            record_progress(step_increment=1, prompt_index=i, description="prompt_completed_with_error", prompt_completed=True)
+
     # Save evaluation results to the session
     sessions[request.session_id]["evaluation_results"] = results
-    
+
     # Save to a results file
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     result_file = os.path.join(RESULTS_DIR, f"evaluation_{request.session_id}_{timestamp}.json")
@@ -654,39 +716,52 @@ async def evaluate_target_llm(request: EvaluationRequest):
         "category_stats": category_stats,
         "result_file": result_file
     }
-    
+
+    progress_data = session.get("evaluation_progress")
+    if progress_data:
+        total_steps = progress_data.get("total_steps")
+        if total_steps is not None:
+            progress_data["completed_steps"] = total_steps
+        progress_data["completed_prompts"] = progress_data.get("total_prompts", len(results))
+        progress_data["current_step_description"] = "completed"
+        progress_data["last_update"] = datetime.now().isoformat()
+
     return {
         "summary": summary,
         "results": results
     }
 
-@app.get("/evaluation_progress/{session_id}/{prompt_index}")
-async def get_evaluation_progress(session_id: str, prompt_index: int):
+@app.get("/evaluation_progress/{session_id}")
+async def get_evaluation_progress(session_id: str):
     """Get evaluation progress"""
     if session_id not in sessions:
         raise HTTPException(status_code=404, detail="セッションが見つかりません")
-    
+
     session = sessions[session_id]
-    
+
     if not session["adversarial_prompts"]:
         raise HTTPException(status_code=400, detail="敵対的プロンプトが見つかりません")
-    
-    total_prompts = len(session["adversarial_prompts"])
-    
-    if int(prompt_index) >= total_prompts:
-        prompt_index = total_prompts - 1
-    
-    # Current prompt information
-    current_prompt = session["adversarial_prompts"][int(prompt_index)]
-    
-    # Calclation of progress rate
-    progress = round((int(prompt_index) + 1) / total_prompts * 100)
-    
+
+    progress_data = session.get("evaluation_progress") or {}
+
+    total_prompts = progress_data.get("total_prompts") or len(session["adversarial_prompts"])
+    total_steps = progress_data.get("total_steps") or 0
+    completed_steps = progress_data.get("completed_steps") or 0
+
+    if total_steps > 0:
+        progress_percentage = round(completed_steps / total_steps * 100)
+    else:
+        progress_percentage = 0
+
     return {
-        "progress": progress,
-        "current_index": int(prompt_index),
-        "total": total_prompts,
-        "current_prompt": current_prompt
+        "progress": progress_percentage,
+        "completed_steps": completed_steps,
+        "total_steps": total_steps,
+        "completed_prompts": progress_data.get("completed_prompts", 0),
+        "total_prompts": total_prompts,
+        "current_prompt_index": progress_data.get("current_prompt_index"),
+        "current_step_description": progress_data.get("current_step_description"),
+        "last_update": progress_data.get("last_update"),
     }
 
 @app.get("/results/{session_id}", response_class=HTMLResponse)

--- a/llm-evaluation-system/automated_rt/templates/index.html
+++ b/llm-evaluation-system/automated_rt/templates/index.html
@@ -208,7 +208,8 @@
                 <div class="progress mb-2">
                     <div class="progress-bar" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div>
                 </div>
-                <p class="text-center"><span data-i18n-progress="evaluation.progress_head">進捗状況:</span> <span id="completedPrompts">0</span> / <span id="totalPrompts">0</span> <span data-i18n-progress="evaluation.progress_tail">プロンプト完了</span></p>
+                <p class="text-center"><span data-i18n-progress="evaluation.progress_head">進捗状況:</span> <span id="completedSteps">0</span> / <span id="totalSteps">0</span> <span data-i18n-progress="evaluation.progress_tail">ステップ完了</span></p>
+                <p class="text-center"><span data-i18n-progress="evaluation.prompt_progress_head">プロンプト進捗:</span> <span id="completedPrompts">0</span> / <span id="totalPrompts">0</span> <span data-i18n-progress="evaluation.prompt_progress_tail">プロンプト完了</span></p>
                 <p class="text-center" id="estimatedTimeRemaining"></p>
             </div>
 


### PR DESCRIPTION
## Summary
- track evaluation progress on the server at per-step granularity with cumulative step and prompt counts exposed via /evaluation_progress/{session_id}
- update the automated RT frontend to poll the new endpoint while the evaluation request is running, refreshing the progress bar, step/prompt counters, and remaining time estimate from server data
- revise the progress area markup and translations to show both step-level and prompt-level progress text

## Testing
- python -m compileall llm-evaluation-system/automated_rt/app.py

------
https://chatgpt.com/codex/tasks/task_b_6901dd1bffa083329736269efbbdec92