### PR TITLE
Load grade pattern from optional config

### DIFF
--- a/backend/src/constants/config.py
+++ b/backend/src/constants/config.py
@@ -1,0 +1,1 @@
+GRADE_PATTERN = r"(?i)GRADE\s*:\s*([CPI])(.*)"

--- a/backend/src/manager/evaluation_results_manager.py
+++ b/backend/src/manager/evaluation_results_manager.py
@@ -1,4 +1,6 @@
 from datetime import date, datetime
+import importlib.util
+from pathlib import Path
 from src.db.define_tables import EvaluationResult, Dataset, AIModel, Evaluation, AIModel, UseGSN
 from sqlalchemy.orm import Session
 from src.utils.logger import logger
@@ -146,7 +148,17 @@ class EvaluationResultsManager:
 
         scorer_provider = ScorerProvider()
 
-        grade_pattern = r"(?i)GRADE\s*:\s*([CPI])(.*)"
+        grade_pattern = None
+        config_path = Path(__file__).resolve().parents[1] / "constants" / "config.py"
+
+        if config_path.is_file():
+            spec = importlib.util.spec_from_file_location(
+                "src.constants.config", config_path)
+
+            if spec and spec.loader:
+                config = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(config)
+                grade_pattern = getattr(config, "GRADE_PATTERN", None)
 
         # Select ScorerProvider method from scorer name
         if scorer_name == "exact":


### PR DESCRIPTION
## Summary
- add backend/src/constants/config.py with the existing grade pattern default
- update get_scorer to load GRADE_PATTERN from the optional config file and fall back to None when unavailable

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6948b4a55c2883329f39b03d247ab804)