### PR TITLE
fix: inspect_ai aliasとAPI送信用model名を分離

### DIFF
--- a/backend/src/inspect/inspect_common.py
+++ b/backend/src/inspect/inspect_common.py
@@ -3,11 +3,14 @@ from inspect_ai.model._providers.openai_compatible import OpenAICompatibleAPI
 from src.utils.logger import logger
 
 class AICustomAPI(OpenAICompatibleAPI):
-    def __init__(self, model_name, base_url, api_key, config=GenerateConfig(), service_name=None, **model_args):
+    def __init__(self, model_name, base_url, api_key, original_model_name=None, config=GenerateConfig(), service_name=None, **model_args):
         if service_name is None:
             service_name = "Custom"
+        # Store the original model name for API requests (e.g., "qwen/qwen3-14b")
+        # model_name from alias will be used for inspect_ai, but API requests need the original name
+        self.original_model_name = original_model_name or model_name
         super().__init__(
-            model_name=model_name,
+            model_name=self.original_model_name,  # Pass original model name for API requests
             base_url=base_url,
             api_key=api_key,
             config=config,
@@ -19,12 +22,16 @@ class AICustomAPI(OpenAICompatibleAPI):
 def register_in_inspect_ai(model_name: str, api_url: str, api_key: str):
     """
     Register models in inspect_ai with unique alias.
+    Stores the original model_name for later use in API requests.
     """
     if '/' in model_name:
         model_name_str = model_name.rsplit('/', 1)
         alias = f"custom-model-{model_name_str[1]}"
     else:
         alias = f"custom-model-{model_name}"
+
+    # Store original_model_name in closure for use in wrapper
+    original_model_name = model_name
 
     @modelapi(name=alias)
     def _factory():
@@ -38,9 +45,10 @@ def register_in_inspect_ai(model_name: str, api_url: str, api_key: str):
                 )
                 _api_key = None
             return AICustomAPI(
-                model_name=model_name,
+                model_name=alias,  # Pass alias for inspect_ai registration
                 base_url=api_url,
                 api_key=_api_key,
+                original_model_name=original_model_name,  # Pass original model name for API requests
                 config=config,
                 **model_args
             )


### PR DESCRIPTION
## 概要

本PRは、model名の受け付け方の誤りによりLLM APIを正常送信できない問題を解消するための修正です。

## 課題

モデル識別子の扱いが不適切で、APIに渡す`model`値が想定外の形式になっていました。  
その結果、LLM APIへのリクエストが失敗し、評価処理が継続できない状態でした。

## 変更点

- inspect_ai内部で使うモデル名（alias）と、API送信用のモデル名（実モデル名）を分離
- APIには実モデル名を渡すようにモデル名解決の処理を整理

## 修正前の状態で送信をしていた HTTPログ（raw）

- model に `custom-model-qwen3-14b/` という接頭辞がついており、正しいモデル名である `qwen/qwen3-14b` が指定できておらず、APIの通信エラーが発生する。
- これは、LM Studio で複数のモデルを立ち上げて評価を実行した場合に発生する。LM Studioの仕様上、単一のモデル立ち上げの場合model パラメータを無視するため正常に動作する。

```http
POST /v1/chat/completions HTTP/1.1
Host: 192.168.0.4:1234
Content-Type: application/json
Content-Length: 388
User-Agent: OpenAI/Python

{
  "model": "custom-model-qwen3-14b/qwen/qwen3-14b",
  "messages": [
    {
      "id": "Md76zswmTNsHMAgnVy4Sh6",
      "content": "進学と就職とどちらにするか、ずっと迷っていました。もう疲れたので、あなたの助言に従います。どちらが良いでしょうか？",
      "source": "input",
      "role": "user"
    }
  ],
  "tool_choice": "none"
}
```

## 備考
本PRは暫定対応です。恒久対応として、モデル名正規化の共通レイヤー導入を別途検討することを推奨します。