### PR TITLE
Automated Red Teaming: Fix a bug when RT calls local LLMs on Ollama

### DIFF
--- a/llm-evaluation-system/automated_rt/app.py
+++ b/llm-evaluation-system/automated_rt/app.py
@@ -451,7 +451,7 @@ async def export_adversarial_prompts(session_id: str):
 
 def adversarial_prompt_check(prompt_text):
     """Quick checking for denial of generation"""
-    if prompt_text.startwith("申し訳ありません"):
+    if prompt_text.startswith("申し訳ありません"):
         return False
     return True
 

--- a/llm-evaluation-system/automated_rt/llm_client.py
+++ b/llm-evaluation-system/automated_rt/llm_client.py
@@ -160,36 +160,25 @@ class OllamaClient(LLMClient):
             api_base: Base URL of Ollama API (If none, the default localhost:11434 will be used)
         """
         self.model_name = model_name
-        self.api_base = api_base or "http://localhost:11434"
-        self.api_url = f"{self.api_base}/api/chat"
+        self.api_base = api_base or "http://localhost:11434/v1/"
+        self.client = openai.AsyncOpenAI(base_url=self.api_base, api_key='dummy_key')
+
     
+    #   Using OpenAI compatible API
     async def generate(self, system_prompt: str, user_prompt: str) -> str:
-        """Get generated responses using the Ollama API"""
+        """Get generated responses using the OpenAI API"""
         try:
-            payload = {
-                "model": self.model_name,
-                "messages": [
+            response = await self.client.chat.completions.create(
+                model=self.model_name,
+                messages=[
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt}
                 ],
-                "options": {
-                    #"temperature": 0.7,
-                    "num_predict": 4000
-                }
-            }
-            
-            async with aiohttp.ClientSession() as session:
-                async with session.post(self.api_url, json=payload) as response:
-                    if response.status != 200:
-                        error_text = await response.text()
-                        return f"エラー: Ollama API呼び出しに失敗しました (ステータス {response.status}): {error_text}"
-                    
-                    result = await response.json()
-                    if "message" in result and "content" in result["message"]:
-                        return result["message"]["content"]
-                    
-                    return str(result)
+                #temperature=0.7,
+                #max_tokens=4000
+                max_completion_tokens=4000
+            )
+            return response.choices[0].message.content
         except Exception as e:
-            print(f"Ollama API error: {e}")
+            print(f"Ollama/OpenAI API error: {e}")
             return f"エラー: {str(e)}"
-

--- a/llm-evaluation-system/automated_rt/static/js/main.js
+++ b/llm-evaluation-system/automated_rt/static/js/main.js
@@ -440,7 +440,7 @@ const textMap = {
     "ターゲットAIは評価対象のため、システムプロンプトを自由に設定できます。": { ja: "ターゲットAIは評価対象のため、システムプロンプトを自由に設定できます。", en: "As the target AI is under evaluation, you can configure its system prompt freely." },
     "ターゲットプレフィックス:": { ja: "ターゲットプレフィックス:", en: "Target prefix:" },
     "デフォルトに戻す": { ja: "デフォルトに戻す", en: "Reset to default" },
-    "デフォルトは http://localhost:11434 です": { ja: "デフォルトは http://localhost:11434 です", en: "The default is http://localhost:11434." },
+    "STR_NOTES_FOR_OLLAMA_ENDPOINT": { ja: "通常の形式は http://**IPアドレス**:11434/v1/ です", en: "The typical format is http://**IP_address**:11434/v1/ ." },
     "ドキュメントのアップロード": { ja: "ドキュメントのアップロード", en: "Upload documents" },
     "ドキュメントファイル（PDF）:": { ja: "ドキュメントファイル（PDF）:", en: "Document file (PDF):" },
     "プロキシURL:": { ja: "プロキシURL:", en: "Proxy URL:" },

--- a/llm-evaluation-system/automated_rt/templates/index.html
+++ b/llm-evaluation-system/automated_rt/templates/index.html
@@ -269,19 +269,14 @@
                                             <small class="text-muted hf-info" style="display: none;">Hugging Faceの場合、デフォルトは "meta-llama/Meta-Llama-3-8B-Instruct"</small>
                                             <small class="text-muted ollama-info" style="display: none;">Ollamaの場合、デフォルトは "llama3" または "llama3:8b"</small>
                                         </div>
-                                        <div class="mb-3">
+                                        <div class="mb-3 openai-only azure-only hf-only">
                                             <label for="reqLlmApiKey" class="form-label">APIキー (オプション):</label>
                                             <input type="password" class="form-control" id="reqLlmApiKey">
-                                            <small class="text-muted">環境変数から取得する場合は空欄</small>
                                         </div>
-                                        <div class="mb-3 azure-only" style="display: none;">
+                                        <div class="mb-3 azure-only ollama-only" style="display: none;">
                                             <label for="reqLlmApiBase" class="form-label">APIエンドポイント:</label>
                                             <input type="text" class="form-control" id="reqLlmApiBase">
-                                        </div>
-                                        <div class="mb-3 ollama-only" style="display: none;">
-                                            <label for="reqLlmApiBase" class="form-label">Ollama APIエンドポイント:</label>
-                                            <input type="text" class="form-control" id="reqLlmApiBase" placeholder="http://localhost:11434">
-                                            <small class="text-muted">デフォルトは http://localhost:11434 です</small>
+                                            <small class="text-muted ollama-only" style="display: none;">STR_NOTES_FOR_OLLAMA_ENDPOINT</small>
                                         </div>
                                         <div hidden class="mb-3">
                                             <label for="reqLlmSystemPrompt" class="form-label">追加システムプロンプト (オプション):</label>
@@ -363,18 +358,14 @@
                                             <small class="text-muted hf-info" style="display: none;">Hugging Faceの場合、デフォルトは "meta-llama/Meta-Llama-3-8B-Instruct"</small>
                                             <small class="text-muted ollama-info" style="display: none;">Ollamaの場合、デフォルトは "llama3" または "llama3:8b"</small>
                                         </div>
-                                        <div class="mb-3">
+                                        <div class="mb-3 openai-only azure-only hf-only">
                                             <label for="advLlmApiKey" class="form-label">APIキー (オプション):</label>
                                             <input type="password" class="form-control" id="advLlmApiKey">
                                         </div>
-                                        <div class="mb-3 azure-only" style="display: none;">
+                                        <div class="mb-3 azure-only ollama-only" style="display: none;">
                                             <label for="advLlmApiBase" class="form-label">APIエンドポイント:</label>
                                             <input type="text" class="form-control" id="advLlmApiBase">
-                                        </div>
-                                        <div class="mb-3 ollama-only" style="display: none;">
-                                            <label for="advLlmApiBase" class="form-label">Ollama APIエンドポイント:</label>
-                                            <input type="text" class="form-control" id="advLlmApiBase" placeholder="http://localhost:11434">
-                                            <small class="text-muted">デフォルトは http://localhost:11434 です</small>
+                                            <small class="text-muted ollama-only" style="display: none;">STR_NOTES_FOR_OLLAMA_ENDPOINT</small>
                                         </div>
                                         <div hidden class="mb-3">
                                             <label for="advLlmSystemPrompt" class="form-label">追加システムプロンプト (オプション):</label>
@@ -458,18 +449,14 @@
                                             <small class="text-muted hf-info" style="display: none;">Hugging Faceの場合、デフォルトは "meta-llama/Meta-Llama-3-8B-Instruct"</small>
                                             <small class="text-muted ollama-info" style="display: none;">Ollamaの場合、デフォルトは "llama3" または "llama3:8b"</small>
                                         </div>
-                                        <div class="mb-3">
+                                        <div class="mb-3 openai-only azure-only hf-only">
                                             <label for="evalLlmApiKey" class="form-label">APIキー (オプション):</label>
                                             <input type="password" class="form-control" id="evalLlmApiKey">
                                         </div>
-                                        <div class="mb-3 azure-only" style="display: none;">
+                                        <div class="mb-3 azure-only ollama-only" style="display: none;">
                                             <label for="evalLlmApiBase" class="form-label">APIエンドポイント:</label>
                                             <input type="text" class="form-control" id="evalLlmApiBase">
-                                        </div>
-                                        <div class="mb-3 ollama-only" style="display: none;">
-                                            <label for="evalLlmApiBase" class="form-label">Ollama APIエンドポイント:</label>
-                                            <input type="text" class="form-control" id="evalLlmApiBase" placeholder="http://localhost:11434">
-                                            <small class="text-muted">デフォルトは http://localhost:11434 です</small>
+                                            <small class="text-muted ollama-only" style="display: none;">STR_NOTES_FOR_OLLAMA_ENDPOINT</small>
                                         </div>
                                         <div hidden class="mb-3">
                                             <label for="evalLlmSystemPrompt" class="form-label">追加システムプロンプト (オプション):</label>
@@ -509,18 +496,14 @@
                                             <small class="text-muted ollama-info" style="display: none;">Ollamaの場合、デフォルトは "llama3" または "llama3:8b"</small>
                                             <small class="text-muted custom-endpoint-only" style="display: none;">カスタムエンドポイントの場合は任意の値を設定できます</small>
                                         </div>
-                                        <div class="mb-3">
+                                        <div class="mb-3 openai-only azure-only hf-only">
                                             <label for="targetLlmApiKey" class="form-label">APIキー (オプション):</label>
                                             <input type="password" class="form-control" id="targetLlmApiKey">
                                         </div>
-                                        <div class="mb-3 azure-only" style="display: none;">
+                                        <div class="mb-3 azure-only ollama-only" style="display: none;">
                                             <label for="targetLlmApiBase" class="form-label">APIエンドポイント:</label>
                                             <input type="text" class="form-control" id="targetLlmApiBase">
-                                        </div>
-                                        <div class="mb-3 ollama-only" style="display: none;">
-                                            <label for="targetLlmApiBase" class="form-label">Ollama APIエンドポイント:</label>
-                                            <input type="text" class="form-control" id="targetLlmApiBase" placeholder="http://localhost:11434">
-                                            <small class="text-muted">デフォルトは http://localhost:11434 です</small>
+                                            <small class="text-muted ollama-only" style="display: none;">STR_NOTES_FOR_OLLAMA_ENDPOINT</small>
                                         </div>
                                         
                                         <!-- カスタムエンドポイント固有の設定フィールド -->
@@ -652,6 +635,8 @@ document.addEventListener('DOMContentLoaded', function() {
             const parentCard = this.closest('.card');
             const azureFields = parentCard.querySelectorAll('.azure-only');
             const ollamaFields = parentCard.querySelectorAll('.ollama-only');
+            const openaiFields = parentCard.querySelectorAll('.openai-only');
+            const hfFields = parentCard.querySelectorAll('.hf-only');
             const hfInfos = parentCard.querySelectorAll('.hf-info');
             const ollamaInfos = parentCard.querySelectorAll('.ollama-info');
             const customEndpointFields = parentCard.querySelectorAll('.custom-endpoint-only');
@@ -660,6 +645,8 @@ document.addEventListener('DOMContentLoaded', function() {
             // Reset all fields
             azureFields.forEach(field => field.style.display = 'none');
             ollamaFields.forEach(field => field.style.display = 'none');
+            openaiFields.forEach(field => field.style.display = 'none');
+            hfFields.forEach(field => field.style.display = 'none');
             hfInfos.forEach(info => info.style.display = 'none');
             ollamaInfos.forEach(info => info.style.display = 'none');
             customEndpointFields.forEach(field => field.style.display = 'none');
@@ -676,6 +663,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     modelInput.value = 'llama3';
                 }
             } else if (this.value === 'huggingface') {
+                hfFields.forEach(field => field.style.display = 'block');
                 hfInfos.forEach(info => info.style.display = 'block');
                 
                 // Set the default model name
@@ -690,6 +678,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     modelInput.value = 'custom';
                 }
             } else if (this.value === 'openai') {
+                openaiFields.forEach(field => field.style.display = 'block');
                 // Reset to OpenAI's default model
                 if (modelInput.value === 'llama3' || modelInput.value === 'meta-llama/Meta-Llama-3-8B-Instruct' || modelInput.value === 'custom') {
                     const cardHeader = parentCard.querySelector('.card-header');


### PR DESCRIPTION
Automated Red Teaming: Fix a bug when RT calls local LLMs on Ollama

- Fixed an HTML of LLM settings screen for enabling configuration of an API endpoint
- Using OpenAI compatible API instead of Ollama API. As a result, The API endpoint should be like "http://##IP_address##:11434/v1/" 